### PR TITLE
feat: BaseTimeEntity추가

### DIFF
--- a/src/main/java/com/moing/backend/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/moing/backend/domain/auth/presentation/AuthController.java
@@ -68,4 +68,5 @@ public class AuthController {
         return ResponseEntity.ok(SuccessResponse.create(REISSUE_TOKEN_SUCCESS.getMessage(), reissueToken));
     }
 
+    //TODO 닉네임 중복검사
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
@@ -3,6 +3,7 @@ package com.moing.backend.domain.member.domain.entity;
 import com.moing.backend.domain.member.domain.constant.RegistrationStatus;
 import com.moing.backend.domain.member.domain.constant.Role;
 import com.moing.backend.domain.member.domain.constant.SocialProvider;
+import com.moing.backend.global.entity.BaseTimeEntity;
 import com.moing.backend.global.util.AesConverter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +19,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class Member {
+public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
@@ -41,11 +42,10 @@ public class Member {
     @Convert(converter = AesConverter.class)
     private String profileImage; //없으면 undef
 
-
     private String gender; //없으면 undef
 
-
     private String ageRange; //없으면 undef
+
     private boolean isDeleted;
 
     // 추가정보
@@ -59,10 +59,7 @@ public class Member {
     @Convert(converter = AesConverter.class)
     private String introduction; //없으면 undef
 
-
     private String fcmToken; //없으면 undef
-
-    private String reasonToDelete; //없으면 undef
 
     @ColumnDefault("true")
     private boolean isNewUploadPush;
@@ -97,7 +94,6 @@ public class Member {
         if (nickName == null) nickName = "undef";
         if (introduction == null) introduction = "undef";
         if (fcmToken == null) fcmToken = "undef";
-        if (reasonToDelete == null) reasonToDelete = "undef";
         if (registrationStatus == null) registrationStatus = RegistrationStatus.UNCOMPLETED;
     }
 
@@ -132,7 +128,6 @@ public class Member {
 
     public void deleteAccount(String reasonToDelete) {
         this.isDeleted = true;
-        this.reasonToDelete = reasonToDelete;
     }
 
     public void updateNewUploadPush(boolean newUploadPush) {

--- a/src/main/java/com/moing/backend/domain/mypage/presentation/MyPageController.java
+++ b/src/main/java/com/moing/backend/domain/mypage/presentation/MyPageController.java
@@ -1,0 +1,6 @@
+package com.moing.backend.domain.mypage.presentation;
+
+public class MyPageController {
+
+    //TODO 회원탍퇴, 로그아웃, 마이페이지 조회, 수정, 알림설정 수정
+}

--- a/src/main/java/com/moing/backend/global/config/webclient/WebClientConfig.java
+++ b/src/main/java/com/moing/backend/global/config/webclient/WebClientConfig.java
@@ -30,7 +30,7 @@ public class WebClientConfig {
                 .exchangeStrategies(exchangeStrategies)
                 .filter(logRequest())
                 .filter(logResponse())
-                .defaultHeader("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.3")
+                .defaultHeader("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36")
                 .build();
     }
 

--- a/src/main/java/com/moing/backend/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/moing/backend/global/entity/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.moing.backend.global.entity;
+
+import jodd.typeconverter.impl.LocalDateTimeConverter;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+
+}


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
BaseTimeEntity추가

## 변경 사항
db에 저장되는 엔티티는 (진짜 필요없는 경우 제외하고는) BaseTimeEntity를 상속받아서 사용하기!!
이건 나름 중요한 것 같아서 호다닥 수정해서 pr 날립니다!

## 코드 리뷰 시 참고 사항

## 테스트 결과
