### PR TITLE
feat : 미션 인증 좋아요, 인증 인원 조회, 팀별 미션 개수 조회

### DIFF
--- a/src/docs/asciidoc/MissionArchive-API.adoc
+++ b/src/docs/asciidoc/MissionArchive-API.adoc
@@ -27,3 +27,15 @@ operation::mission-archive-controller-test/모임원_미션_인증_조회[snippe
 
 ---
 
+[[MissionArchive-인증성공인원조회]]
+=== 인증 성공 인원 조회 ( n/n명 )
+operation::mission-archive-controller-test/인증_성공_인원_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+---
+
+[[MissionArchive-미션인증물좋아요]]
+=== 미션 인증물 좋아요
+operation::mission-archive-controller-test/미션_인증물_좋아요[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+---
+

--- a/src/docs/asciidoc/Overview.adoc
+++ b/src/docs/asciidoc/Overview.adoc
@@ -116,7 +116,15 @@
 | 소모임장이 아님
 
 | `M0002`
-| API PATH에 missionId가 있으 때
-| missionId가 유요하지 않음
+| API PATH에 missionId가 있을 때
+| missionId가 유효하지 않음
+|===
+
+=== MissionArchive ErrorCode
+|===
+| ErrorCode | Scope | Description
+| `MA0001`
+| 미션 인증물 조회할 때
+| 미션 missionId 또는 teamId가 유효하지 않음
 |===
 

--- a/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepository.java
@@ -1,0 +1,5 @@
+package com.moing.backend.domain.mission.domain.repository;
+
+public interface MissionCustomRepository {
+    Long findMissionsCountByTeam(Long teamId);
+}

--- a/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.moing.backend.domain.mission.domain.repository;
+
+import com.moing.backend.domain.mission.domain.entity.Mission;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import javax.persistence.EntityManager;
+
+import static com.moing.backend.domain.mission.domain.entity.QMission.mission;
+
+public class MissionCustomRepositoryImpl implements MissionCustomRepository{
+
+    private final JPAQueryFactory queryFactory;
+    public MissionCustomRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+
+    @Override
+    public Long findMissionsCountByTeam(Long teamId) {
+        return queryFactory
+                .select(mission.count())
+                .from(mission)
+                .where(
+                        mission.team.teamId.eq(teamId)
+                )
+                .fetchFirst();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionRepository.java
+++ b/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionRepository.java
@@ -3,5 +3,5 @@ package com.moing.backend.domain.mission.domain.repository;
 import com.moing.backend.domain.mission.domain.entity.Mission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MissionRepository extends JpaRepository<Mission, Long> {
+public interface MissionRepository extends JpaRepository<Mission, Long>,MissionCustomRepository {
 }

--- a/src/main/java/com/moing/backend/domain/mission/domain/service/MissionQueryService.java
+++ b/src/main/java/com/moing/backend/domain/mission/domain/service/MissionQueryService.java
@@ -17,4 +17,8 @@ public class MissionQueryService {
     public Mission findMissionById(Long missionId) {
         return missionRepository.findById(missionId).orElseThrow(NotFoundMissionException::new);
     }
+
+    public Long findMissionsCountByTeam(Long teamId) {
+        return missionRepository.findMissionsCountByTeam(teamId);
+    }
 }

--- a/src/main/java/com/moing/backend/domain/mission/presentation/MissionController.java
+++ b/src/main/java/com/moing/backend/domain/mission/presentation/MissionController.java
@@ -8,6 +8,7 @@ import com.moing.backend.domain.mission.application.service.MissionDeleteUseCase
 import com.moing.backend.domain.mission.application.service.MissionReadUseCase;
 import com.moing.backend.domain.mission.application.service.MissionUpdateUseCase;
 import com.moing.backend.domain.mission.domain.service.MissionDeleteService;
+import com.moing.backend.domain.mission.domain.service.MissionQueryService;
 import com.moing.backend.global.config.security.dto.User;
 import com.moing.backend.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
@@ -28,6 +29,7 @@ public class MissionController {
     private final MissionReadUseCase missionReadUseCase;
     private final MissionUpdateUseCase missionUpdateUseCase;
     private final MissionDeleteUseCase missionDeleteUseCase;
+    private final MissionQueryService missionQueryService;
 
     /**
      * 미션 조회

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/req/MissionArchiveHeartReq.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/req/MissionArchiveHeartReq.java
@@ -1,12 +1,14 @@
 package com.moing.backend.domain.missionArchive.application.dto.req;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class MissionArchiveHeartReq {
     private Long archiveId;
     private String heartStatus;

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchiveStatusRes.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchiveStatusRes.java
@@ -1,0 +1,11 @@
+package com.moing.backend.domain.missionArchive.application.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MissionArchiveStatusRes {
+    private String total;
+    private String done;
+}

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/SingleMissionArchiveReadUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/SingleMissionArchiveReadUseCase.java
@@ -5,11 +5,13 @@ import com.moing.backend.domain.member.domain.service.MemberGetService;
 import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.mission.domain.service.MissionQueryService;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveStatusRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.PersonalArchive;
 import com.moing.backend.domain.missionArchive.application.mapper.MissionArchiveMapper;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
 import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.domain.team.domain.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +30,7 @@ public class SingleMissionArchiveReadUseCase {
     private final MemberGetService memberGetService;
     private final MissionQueryService missionQueryService;
     private final MissionArchiveQueryService missionArchiveQueryService;
+    private final TeamRepository teamRepository;
 
 
     // 미션 인증 조회
@@ -49,6 +52,17 @@ public class SingleMissionArchiveReadUseCase {
         return MissionArchiveMapper.mapToPersonalArchiveList(missionArchiveQueryService.findOthersArchive(member.getMemberId(), missionId));
 
 //        return personalArchives;
+    }
+
+    public MissionArchiveStatusRes getMissionDoneStatus(Long missionId) {
+        Mission mission = missionQueryService.findMissionById(missionId);
+        Team team = mission.getTeam();
+
+        return MissionArchiveStatusRes.builder()
+                .total(team.getNumOfMember().toString())
+                .done(missionArchiveQueryService.findDoneArchives(missionId).toString())
+                .build();
+
     }
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/constant/MissionArchiveResponseMessage.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/constant/MissionArchiveResponseMessage.java
@@ -11,7 +11,8 @@ public enum MissionArchiveResponseMessage {
     READ_MY_ARCHIVE_SUCCESS("나의 미션 인증 현황 조회를 완료 했습니다."),
     READ_TEAM_ARCHIVE_SUCCESS("팀원 미션 인증 현황 조회를 완료 했습니다."),
     HEART_UPDATE_SUCCESS("미션 인증 좋아요를 성공적으로 눌렀습니다."),
-    ACTIVE_SINGLE_MISSION_SUCCESS("진행 중인 한번 인증 미션 조회를 완료하였습니다."),
+    MISSION_ARCHIVE_PEOPLE_STATUS_SUCCESS("미션 인증 성공한 인원 상태 조회를 완료 했습니다."),
+    ACTIVE_SINGLE_MISSION_SUCCESS("진행 중인 한번 인증 미션 조회를 완료 했습니다."),
     FINISH_ALL_MISSION_SUCCESS("종료된 미션 조회를 완료하였습니다.");
 
     private final String message;

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepository.java
@@ -14,5 +14,8 @@ public interface MissionArchiveCustomRepository {
 
     Optional<List<MissionArchive>> findAllMissionArchivesByMemberId(Long memberId, Long teamId, MissionStatus missionStatus);
 
+    Optional<Long> findDonePeopleByMissionId(Long missionId);
+
+
 
     }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
@@ -92,5 +92,18 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
         );
     }
 
+    @Override
+    public Optional<Long> findDonePeopleByMissionId(Long missionId) {
+        return Optional.ofNullable(queryFactory
+                .select(missionArchive.count())
+                .from(missionArchive)
+                .where(
+                        missionArchive.mission.id.eq(missionId)
+                )
+                .fetchFirst()
+
+        );
+    }
+
 
 }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
@@ -87,6 +87,10 @@ public class MissionArchiveQueryService {
         return missionArchiveRepository.findAllMissionArchivesByMemberId(memberId, teamId, missionStatus).orElseThrow(NotFoundMissionArchiveException::new);
     }
 
+    public Long findDoneArchives(Long missionId) {
+        return missionArchiveRepository.findDonePeopleByMissionId(missionId).orElseThrow(NotFoundMissionArchiveException::new);
+    }
+
 
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
@@ -36,7 +36,7 @@ public class MissionArchiveController {
      * 미션 인증 하기
      * [POST] {teamId}/missions/{missionId}/archive
      * 작성자 : 정승연
-     */
+     **/
 
     @PostMapping()
     public ResponseEntity<SuccessResponse<MissionArchiveRes>> createArchive(@AuthenticationPrincipal User user,
@@ -50,7 +50,7 @@ public class MissionArchiveController {
      * 미션 재인증 하기
      * [POST] {teamId}/missions/{missionId}/archive
      * 작성자 : 정승연
-     */
+     **/
 
     @PutMapping()
     public ResponseEntity<SuccessResponse<MissionArchiveRes>> updateArchive(@AuthenticationPrincipal User user,
@@ -64,7 +64,7 @@ public class MissionArchiveController {
      * 미션 인증 조회
      * [GET] {teamId}/missions/{missionId}/archive
      * 작성자 : 정승연
-     */
+     **/
 
     @GetMapping()
     public ResponseEntity<SuccessResponse<MissionArchiveRes>> getMyArchive(@AuthenticationPrincipal User user,
@@ -77,7 +77,7 @@ public class MissionArchiveController {
      * 모임원 미션 인증 목록 조회
      * [GET] {teamId}/missions/{missionId}/archive/others
      * 작성자 : 정승연
-     */
+     **/
     @GetMapping("/others")
     public ResponseEntity<SuccessResponse<List<PersonalArchive>>> getOtherPeopleArchives(@AuthenticationPrincipal User user,
                                                                                   @PathVariable("teamId") Long teamId,
@@ -85,7 +85,11 @@ public class MissionArchiveController {
         return ResponseEntity.ok(SuccessResponse.create(READ_TEAM_ARCHIVE_SUCCESS.getMessage(), this.singleMissionArchiveReadUseCase.getPersonalArchive(user.getSocialId(),missionId)));
     }
 
-
+    /**
+     * 인증 성공 인원 조회
+     * [GET] {teamId}/m원issions/{missionId}/archive/status
+     * 작성자 : 정승연
+     **/
 
     @GetMapping("/status")
     public ResponseEntity<SuccessResponse<MissionArchiveStatusRes>> getMissionDoneStatus(@AuthenticationPrincipal User user,
@@ -94,6 +98,11 @@ public class MissionArchiveController {
         return ResponseEntity.ok(SuccessResponse.create(MISSION_ARCHIVE_PEOPLE_STATUS_SUCCESS.getMessage(), this.singleMissionArchiveReadUseCase.getMissionDoneStatus(missionId)));
     }
 
+    /**
+     * 미션 인증 게시물 좋아요
+     * [GET] {teamId}/m원issions/{missionId}/archive/hearts
+     * 작성자 : 정승연
+     **/
 
     @PostMapping("/hearts")
     public ResponseEntity<SuccessResponse<MissionArchiveHeartRes>> pushHeart(@AuthenticationPrincipal User user,

--- a/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
@@ -4,6 +4,7 @@ import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiv
 import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveHeartReq;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveHeartRes;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveStatusRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.PersonalArchive;
 import com.moing.backend.domain.missionArchive.application.service.MissionArchiveCreateUseCase;
 import com.moing.backend.domain.missionArchive.application.service.MissionArchiveHeartUseCase;
@@ -83,6 +84,16 @@ public class MissionArchiveController {
                                                                                   @PathVariable("missionId") Long missionId) {
         return ResponseEntity.ok(SuccessResponse.create(READ_TEAM_ARCHIVE_SUCCESS.getMessage(), this.singleMissionArchiveReadUseCase.getPersonalArchive(user.getSocialId(),missionId)));
     }
+
+
+
+    @GetMapping("/status")
+    public ResponseEntity<SuccessResponse<MissionArchiveStatusRes>> getMissionDoneStatus(@AuthenticationPrincipal User user,
+                                                                                         @PathVariable("teamId") Long teamId,
+                                                                                         @PathVariable("missionId") Long missionId) {
+        return ResponseEntity.ok(SuccessResponse.create(MISSION_ARCHIVE_PEOPLE_STATUS_SUCCESS.getMessage(), this.singleMissionArchiveReadUseCase.getMissionDoneStatus(missionId)));
+    }
+
 
     @PostMapping("/hearts")
     public ResponseEntity<SuccessResponse<MissionArchiveHeartRes>> pushHeart(@AuthenticationPrincipal User user,


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- [미션 인증 좋아요, 미션 인증 인원 조회 구현 및 API 문서 추가](https://github.com/Modagbul/MOING_server_release/commit/fc753dc9a00e01ab47f781683f1ee6263a09bba2)
- [팀별 미션 개수 조회 함수 추가](https://github.com/Modagbul/MOING_server_release/commit/e4c4d61806f5ad042e99f0c869bc226d15332cbe)

## 변경 사항
- MissionRepository 에서 queryDSL 사용 추가했습니다! 
- MissionArchiveControllerTest 추가 하였습니다.
https://github.com/Modagbul/MOING_server_release/blob/e4c4d61806f5ad042e99f0c869bc226d15332cbe/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionArchiveControllerTest.java#L292-L397

## 코드 리뷰 시 참고 사항
- 요청주셨던 팀 별 미션 개수 조회 함수 구현 완료했습니다! 
https://github.com/Modagbul/MOING_server_release/blob/e4c4d61806f5ad042e99f0c869bc226d15332cbe/src/main/java/com/moing/backend/domain/mission/domain/service/MissionQueryService.java#L21-L24

## 테스트 결과
https://github.com/Modagbul/MOING_server_release/blob/e4c4d61806f5ad042e99f0c869bc226d15332cbe/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionArchiveControllerTest.java#L292-L397