### PR TITLE
fix: 소모임 탈퇴 후 회원 닉네임 처리 및 test오류 해결 

### DIFF
--- a/src/main/java/com/moing/backend/domain/board/application/dto/response/BoardBlocks.java
+++ b/src/main/java/com/moing/backend/domain/board/application/dto/response/BoardBlocks.java
@@ -26,8 +26,10 @@ public class BoardBlocks {
 
     private Boolean isRead;
 
+    private Boolean writerIsDeleted;
+
     @QueryProjection
-    public BoardBlocks(Long boardId, String writerNickName, Boolean writerIsLeader, String writerProfileImage, String title, String content, Integer commentNum) {
+    public BoardBlocks(Long boardId, String writerNickName, Boolean writerIsLeader, String writerProfileImage, String title, String content, Integer commentNum, Boolean writerIsDeleted) {
         this.boardId = boardId;
         this.writerNickName = writerNickName;
         this.writerIsLeader = writerIsLeader;
@@ -36,9 +38,18 @@ public class BoardBlocks {
         this.content = content;
         this.commentNum = commentNum;
         this.isRead = false;
+        this.writerIsDeleted=writerIsDeleted;
+        deleteMember();
     }
 
     public void readBoard() {
         this.isRead = true;
+    }
+
+    public void deleteMember() {
+        if(Boolean.TRUE.equals(writerIsDeleted)) {
+            this.writerNickName = "(알 수 없음)";
+            this.writerProfileImage = "undef";
+        }
     }
 }

--- a/src/main/java/com/moing/backend/domain/board/domain/repository/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/board/domain/repository/BoardCustomRepositoryImpl.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import static com.moing.backend.domain.board.domain.entity.QBoard.board;
 import static com.moing.backend.domain.boardRead.domain.entity.QBoardRead.boardRead;
 
-public class BoardCustomRepositoryImpl implements BoardCustomRepository {
+public class    BoardCustomRepositoryImpl implements BoardCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     public BoardCustomRepositoryImpl(EntityManager em) {
@@ -51,7 +51,8 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository {
                     b.getWriterProfileImage(),
                     b.getTitle(),
                     b.getContent(),
-                    b.getCommentNum()
+                    b.getCommentNum(),
+                    b.getTeamMember().isDeleted()
             );
             if (isRead) {
                 boardBlocks.readBoard();

--- a/src/main/java/com/moing/backend/domain/boardComment/application/dto/response/CommentBlocks.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/dto/response/CommentBlocks.java
@@ -21,4 +21,11 @@ public class CommentBlocks {
     private String writerProfileImage;
 
     private Boolean isWriter;
+
+    private Boolean writerIsDeleted;
+
+    public void deleteMember(){
+        this.writerNickName="(알 수 없음)";
+        this.writerProfileImage="undef";
+    }
 }

--- a/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepositoryImpl.java
@@ -1,11 +1,7 @@
 package com.moing.backend.domain.boardComment.domain.repository;
 
-import com.moing.backend.domain.board.domain.entity.Board;
 import com.moing.backend.domain.boardComment.application.dto.response.CommentBlocks;
 import com.moing.backend.domain.boardComment.application.dto.response.GetBoardCommentResponse;
-import com.moing.backend.domain.boardComment.application.service.GetBoardCommentUserCase;
-import com.moing.backend.domain.boardComment.domain.entity.BoardComment;
-import com.moing.backend.domain.boardComment.domain.entity.QBoardComment;
 import com.moing.backend.domain.teamMember.domain.entity.QTeamMember;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.querydsl.core.types.ExpressionUtils;
@@ -17,7 +13,6 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 import static com.moing.backend.domain.boardComment.domain.entity.QBoardComment.boardComment;
-import static com.moing.backend.domain.teamMember.domain.entity.QTeamMember.teamMember;
 
 public class BoardCommentCustomRepositoryImpl implements BoardCommentCustomRepository{
 
@@ -42,11 +37,15 @@ public class BoardCommentCustomRepositoryImpl implements BoardCommentCustomRepos
                                 .from(QTeamMember.teamMember)
                                 .where(QTeamMember.teamMember.eq(teamMember)
                                         .and(QTeamMember.teamMember.eq(boardComment.teamMember)))
-                                .exists(), "isWriter")))
+                                .exists(), "isWriter"),
+                        boardComment.teamMember.isDeleted))
                 .from(boardComment)
                 .where(boardComment.board.boardId.eq(boardId))
                 .orderBy(boardComment.createdDate.asc())
                 .fetch();
+
+        commentBlocks.forEach(CommentBlocks::deleteMember);
+
         return new GetBoardCommentResponse(commentBlocks);
     }
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
@@ -79,7 +79,7 @@ public class Member extends BaseTimeEntity {
     @ColumnDefault("true")
     private boolean isFirePush;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member")
     private List<TeamMember> teamMembers = new ArrayList<>(); //최대 3개이므로 양방향
 
     //==생성 메서드==//
@@ -166,6 +166,13 @@ public class Member extends BaseTimeEntity {
         this.registrationStatus = registrationStatus;
         this.role = role;
         this.socialId = socialId;
+    }
+
+    public void deleteTeamMember(){
+        List<TeamMember> teamMemberList=this.getTeamMembers();
+        for(TeamMember teamMember:teamMemberList){
+            teamMember.deleteMember();
+        }
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/mypage/application/service/SignOutUserCase.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/service/SignOutUserCase.java
@@ -2,6 +2,7 @@ package com.moing.backend.domain.mypage.application.service;
 
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.member.domain.service.MemberGetService;
+import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.moing.backend.global.config.security.jwt.TokenUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,8 +12,10 @@ import org.springframework.stereotype.Service;
 public class SignOutUserCase {
 
     private final TokenUtil tokenUtil;
+    private final MemberGetService memberGetService;
 
     public void signOut(String socialId){
+        //TODO: teamMember가 isDeleted가 아닌게 한개라도 있으면 error 반환
         tokenUtil.expireRefreshToken(socialId);
     }
 }

--- a/src/main/java/com/moing/backend/domain/team/application/service/DisbandTeamUserCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/DisbandTeamUserCase.java
@@ -6,6 +6,8 @@ import com.moing.backend.domain.team.application.dto.response.DeleteTeamResponse
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.team.domain.service.TeamGetService;
 import com.moing.backend.domain.team.exception.NotAuthByTeamException;
+import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
+import com.moing.backend.domain.teamMember.domain.service.TeamMemberGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,11 +21,14 @@ public class DisbandTeamUserCase {
     private final MemberGetService memberGetService;
     private final TeamGetService teamGetService;
     private final CheckLeaderUserCase checkLeaderUserCase;
+    private final TeamMemberGetService teamMemberGetService;
 
     public DeleteTeamResponse disbandTeam(String socialId, Long teamId) {
         Member member = memberGetService.getMemberBySocialId(socialId);
         Team team = teamGetService.getTeamByTeamId(teamId);
+
         if (checkLeaderUserCase.isTeamLeader(member, team)) {
+            //TODO: 팀의 모든 멤버 isDeleted true 해주환
             team.deleteTeam();
         } else {
             throw new NotAuthByTeamException();

--- a/src/main/java/com/moing/backend/domain/team/application/service/WithdrawTeamUserCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/WithdrawTeamUserCase.java
@@ -25,7 +25,7 @@ public class WithdrawTeamUserCase {
         Member member = memberGetService.getMemberBySocialId(socialId);
         Team team = teamGetService.getTeamByTeamId(teamId);
         TeamMember teamMember = teamMemberGetService.getTeamMember(member, team);
-        teamMember.withdrawTeam();
+        teamMember.deleteMember();
         return new DeleteTeamResponse(team.getTeamId());
     }
 }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/entity/TeamMember.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/entity/TeamMember.java
@@ -42,7 +42,7 @@ public class TeamMember extends BaseTimeEntity {
         member.getTeamMembers().add(this);
     }
 
-    public void withdrawTeam() {
+    public void deleteMember() {
         this.isDeleted = true;
     }
 }

--- a/src/test/java/com/moing/backend/domain/board/presentation/BoardControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/board/presentation/BoardControllerTest.java
@@ -193,6 +193,7 @@ public class BoardControllerTest extends CommonControllerTest {
                 .boardId(1L)
                 .writerIsLeader(true)
                 .writerNickName("작성자 닉네임")
+                .writerIsDeleted(false)
                 .writerProfileImage("작성자 프로필 이미지")
                 .title("공지 제목")
                 .content("공지 내용")
@@ -204,6 +205,7 @@ public class BoardControllerTest extends CommonControllerTest {
                 .boardId(1L)
                 .writerIsLeader(true)
                 .writerNickName("작성자 닉네임")
+                .writerIsDeleted(false)
                 .writerProfileImage("작성자 프로필 이미지")
                 .title("게시글 제목")
                 .content("게시글 내용")
@@ -246,6 +248,7 @@ public class BoardControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.noticeBlocks[0].writerNickName").description("작성자 닉네임"),
                                         fieldWithPath("data.noticeBlocks[0].writerIsLeader").description("작성자 소모임장 여부"),
                                         fieldWithPath("data.noticeBlocks[0].writerProfileImage").description("작성자 프로필 이미지"),
+                                        fieldWithPath("data.noticeBlocks[0].writerIsDeleted").description("작성자 삭제 여부"),
                                         fieldWithPath("data.noticeBlocks[0].title").description("공지 제목"),
                                         fieldWithPath("data.noticeBlocks[0].content").description("공지 내용"),
                                         fieldWithPath("data.noticeBlocks[0].commentNum").description("공지 댓글 개수"),
@@ -255,6 +258,7 @@ public class BoardControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.notNoticeBlocks[0].writerNickName").description("작성자 닉네임"),
                                         fieldWithPath("data.notNoticeBlocks[0].writerIsLeader").description("작성자 소모임장 여부"),
                                         fieldWithPath("data.notNoticeBlocks[0].writerProfileImage").description("작성자 프로필 이미지"),
+                                        fieldWithPath("data.notNoticeBlocks[0].writerIsDeleted").description("작성자 삭제 여부"),
                                         fieldWithPath("data.notNoticeBlocks[0].title").description("일반 게시글 제목"),
                                         fieldWithPath("data.notNoticeBlocks[0].content").description("일반 게시글 내용"),
                                         fieldWithPath("data.notNoticeBlocks[0].commentNum").description("일반 게시글 댓글 개수"),

--- a/src/test/java/com/moing/backend/domain/boardComment/presentation/BoardCommentControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/boardComment/presentation/BoardCommentControllerTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(BoardCommentController.class)
 public class BoardCommentControllerTest extends CommonControllerTest {
+
     @MockBean
     private CreateBoardCommentUserCase createBoardCommentUserCase;
     @MockBean
@@ -139,6 +140,7 @@ public class BoardCommentControllerTest extends CommonControllerTest {
                 .writerIsLeader(true)
                 .writerNickName("작성자 닉네임")
                 .writerProfileImage("작성자 프로필 이미지")
+                .writerIsDeleted(false)
                 .isWriter(true)
                 .build();
 
@@ -177,6 +179,7 @@ public class BoardCommentControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.commentBlocks[0].writerIsLeader").description("작성자 소모임장 여부"),
                                         fieldWithPath("data.commentBlocks[0].writerNickName").description("작성자 닉네임"),
                                         fieldWithPath("data.commentBlocks[0].writerProfileImage").description("작성자 프로필 이미지"),
+                                        fieldWithPath("data.commentBlocks[0].writerIsDeleted").description("작성자 삭제 여부"),
                                         fieldWithPath("data.commentBlocks[0].isWriter").description("댓글 작성자 여부")
                                 )
 

--- a/src/test/java/com/moing/backend/domain/mission/representation/MissionControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/mission/representation/MissionControllerTest.java
@@ -9,8 +9,10 @@ import com.moing.backend.domain.mission.application.service.MissionDeleteUseCase
 import com.moing.backend.domain.mission.application.service.MissionReadUseCase;
 import com.moing.backend.domain.mission.application.service.MissionUpdateUseCase;
 import com.moing.backend.domain.mission.domain.repository.MissionRepository;
+import com.moing.backend.domain.mission.domain.service.MissionQueryService;
 import com.moing.backend.domain.mission.presentation.MissionController;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -46,6 +48,9 @@ public class MissionControllerTest extends CommonControllerTest {
 
     @MockBean
     private MissionDeleteUseCase missionDeleteUseCase;
+
+    @MockBean
+    private MissionQueryService missionQueryService;
 
 
 


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
소모임 탈퇴 후 닉네임 처리 및 test오류 해결

## 변경 사항
소모임 탈퇴 후 회원 닉네임 (알 수 없음) 으로 보이게 처리
test build오류 의존성 추가해서 해결
빌드 오류가 생겼기에 바로 머지하겠슴니당!

## 코드 리뷰 시 참고 사항

## 테스트 결과
