### PR TITLE
Feat: 소모임 수정 및 요청 메서드

### DIFF
--- a/src/docs/asciidoc/Auth-API.adoc
+++ b/src/docs/asciidoc/Auth-API.adoc
@@ -25,13 +25,14 @@ operation::auth-controller-test/google_소셜_로그인_회원가입_후[snippet
 
 [[Auth-회원가입]]
 === Auth 회원가입
-operation::auth-controller-test/sign_up[snippets='http-request,request-fields,http-response,response-fields']
 |===
-| 성별 |
+| 성별
 | `MAN`
 | `WOMAN`
 | `NEUTRALITY`
 |===
+operation::auth-controller-test/sign_up[snippets='http-request,request-fields,http-response,response-fields']
+
 
 [[Auth-토큰-재발급]]
 === Auth 토큰 재발급

--- a/src/docs/asciidoc/Auth-API.adoc
+++ b/src/docs/asciidoc/Auth-API.adoc
@@ -40,7 +40,7 @@ operation::auth-controller-test/reissue_token[snippets='http-request,http-respon
 
 [[Auth-닉네임-검사]]
 === Auth 닉네임 중복검사 요청
-operation::auth-controller-test/check_nickname_중복o[snippets='http-request']
+operation::auth-controller-test/check_nickname_중복o[snippets='http-request,path-parameters']
 
 === Auth 닉네임 중복인 경우
 operation::auth-controller-test/check_nickname_중복o[snippets='http-response,response-fields']

--- a/src/docs/asciidoc/Team-API.adoc
+++ b/src/docs/asciidoc/Team-API.adoc
@@ -33,10 +33,13 @@ operation::team-controller-test/create_team[snippets='http-request,request-field
 === Team 소모임 가입
 operation::team-controller-test/sign-in_team[snippets='http-request,path-parameters,http-response,response-fields']
 
-
 [[Team-소모임-조회]]
 === Team 소모임 조회
 operation::team-controller-test/get_team[snippets='http-request,http-response,response-fields']
+
+[[Team-소모임-수정]]
+=== Team 소모임 수정
+operation::team-controller-test/update_team[snippets='http-request,path-parameters,http-response,request-fields,response-fields']
 
 [[Team-소모임-강제종료]]
 === Team 소모임 강제종료

--- a/src/main/java/com/moing/backend/domain/team/application/dto/request/UpdateTeamRequest.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/request/UpdateTeamRequest.java
@@ -1,0 +1,26 @@
+package com.moing.backend.domain.team.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+@Getter
+public class UpdateTeamRequest {
+    @NotBlank(message = "name 을 입력해 주세요.")
+    @Size(min = 1, max = 10, message = "name 은 최소 1개, 최대 10개의 문자만 입력 가능합니다.")
+    private String name;
+
+    @NotBlank(message = "introduction 을 입력해 주세요.")
+    @Size(min = 1, max = 300, message = "introduction 은 최소 1개, 최대 300개의 문자만 입력 가능합니다.")
+    private String introduction;
+
+    @NotBlank(message = "profileImgUrl 을 입력해 주세요.")
+    private String profileImgUrl;
+}

--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/UpdateTeamResponse.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/UpdateTeamResponse.java
@@ -1,10 +1,12 @@
 package com.moing.backend.domain.team.application.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class UpdateTeamResponse {
     private Long teamId;
 }

--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/UpdateTeamResponse.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/UpdateTeamResponse.java
@@ -1,0 +1,10 @@
+package com.moing.backend.domain.team.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateTeamResponse {
+    private Long teamId;
+}

--- a/src/main/java/com/moing/backend/domain/team/application/service/UpdateTeamUserCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/UpdateTeamUserCase.java
@@ -1,0 +1,34 @@
+package com.moing.backend.domain.team.application.service;
+
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.member.domain.service.MemberGetService;
+import com.moing.backend.domain.team.application.dto.request.UpdateTeamRequest;
+import com.moing.backend.domain.team.application.dto.response.UpdateTeamResponse;
+import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.domain.team.domain.service.TeamGetService;
+import com.moing.backend.domain.team.exception.NotAuthByTeamException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateTeamUserCase {
+
+    private final MemberGetService memberGetService;
+    private final TeamGetService teamGetService;
+    private final CheckLeaderUserCase checkLeaderUserCase;
+
+    public UpdateTeamResponse updateTeam(UpdateTeamRequest updateTeamRequest, String socialId, Long teamId){
+        Member member = memberGetService.getMemberBySocialId(socialId);
+        Team team=teamGetService.getTeamByTeamId(teamId);
+        if (checkLeaderUserCase.isTeamLeader(member, team)) {
+            team.updateTeam(updateTeamRequest.getName(), updateTeamRequest.getIntroduction(), updateTeamRequest.getProfileImgUrl());
+        } else {
+            throw new NotAuthByTeamException();
+        }
+        return new UpdateTeamResponse(team.getTeamId());
+    }
+}

--- a/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepository.java
@@ -3,9 +3,11 @@ package com.moing.backend.domain.team.domain.repository;
 import com.moing.backend.domain.team.application.dto.response.GetTeamResponse;
 import com.moing.backend.domain.team.domain.entity.Team;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamCustomRepository {
     GetTeamResponse findTeamByMemberId(Long memberId);
     Optional<Team> findTeamByTeamId(Long TeamId);
+    List<Long> findTeamIdByMemberId(Long memberId);
 }

--- a/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepositoryImpl.java
@@ -37,6 +37,19 @@ public class TeamCustomRepositoryImpl implements TeamCustomRepository {
                 .fetchOne());
     }
 
+    @Override
+    public List<Long> findTeamIdByMemberId(Long memberId){
+        return queryFactory
+                .select(team.teamId)
+                .from(teamMember)
+                .innerJoin(teamMember.team, team)
+                .on(teamMember.member.memberId.eq(memberId))
+                .where(team.approvalStatus.eq(ApprovalStatus.APPROVAL)) //승인 되었고
+                .where(team.isDeleted.eq(false)) //강제종료되었는지
+                .where(teamMember.isDeleted.eq(false)) //탈퇴했는지
+                .orderBy(team.approvalTime.asc())
+                .fetch();
+    }
     private List<TeamBlock> getTeamBlock(Long memberId) {
         return queryFactory
                 .select(new QTeamBlock(team.teamId,

--- a/src/main/java/com/moing/backend/domain/team/domain/service/TeamGetService.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/service/TeamGetService.java
@@ -8,7 +8,7 @@ import com.moing.backend.domain.team.exception.NotFoundByTeamIdException;
 import com.moing.backend.global.annotation.DomainService;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Optional;
+import java.util.List;
 
 @DomainService
 @RequiredArgsConstructor
@@ -19,6 +19,10 @@ public class TeamGetService {
         GetTeamResponse getTeamResponse = teamRepository.findTeamByMemberId(member.getMemberId());
         getTeamResponse.updateMemberNickName(member.getNickName());
         return getTeamResponse;
+    }
+
+    public List<Long> getTeamIdByMemberId(Long memberId) {
+        return teamRepository.findTeamIdByMemberId(memberId);
     }
 
     public Team getTeamByTeamId(Long teamId){

--- a/src/main/java/com/moing/backend/domain/team/presentation/TeamController.java
+++ b/src/main/java/com/moing/backend/domain/team/presentation/TeamController.java
@@ -1,9 +1,11 @@
 package com.moing.backend.domain.team.presentation;
 
 import com.moing.backend.domain.team.application.dto.request.CreateTeamRequest;
+import com.moing.backend.domain.team.application.dto.request.UpdateTeamRequest;
 import com.moing.backend.domain.team.application.dto.response.CreateTeamResponse;
 import com.moing.backend.domain.team.application.dto.response.DeleteTeamResponse;
 import com.moing.backend.domain.team.application.dto.response.GetTeamResponse;
+import com.moing.backend.domain.team.application.dto.response.UpdateTeamResponse;
 import com.moing.backend.domain.team.application.service.*;
 import com.moing.backend.global.config.security.dto.User;
 import com.moing.backend.global.response.SuccessResponse;
@@ -26,6 +28,7 @@ public class TeamController {
     private final SignInTeamUserCase signInTeamUserCase;
     private final DisbandTeamUserCase disbandTeamUserCase;
     private final WithdrawTeamUserCase withdrawTeamUserCase;
+    private final UpdateTeamUserCase updateTeamUserCase;
 
     /**
      * 소모임 생성 (only 개설만)
@@ -80,6 +83,18 @@ public class TeamController {
     public ResponseEntity<SuccessResponse<DeleteTeamResponse>> withdrawTeam(@AuthenticationPrincipal User user,
                                                                           @PathVariable Long teamId){
         return ResponseEntity.ok(SuccessResponse.create(WITHDRAW_TEAM_SUCCESS.getMessage(), this.withdrawTeamUserCase.withdrawTeam(user.getSocialId(),teamId)));
+    }
+
+    /**
+     * 소모임 수정 (소모임장)
+     * [POST] api/team/{teamId}
+     */
+
+    @PutMapping("/{teamId}")
+    public ResponseEntity<SuccessResponse<UpdateTeamResponse>> updateTeam(@Valid @RequestBody UpdateTeamRequest updateTeamRequest,
+                                                                          @AuthenticationPrincipal User user,
+                                                                          @PathVariable Long teamId){
+        return ResponseEntity.ok(SuccessResponse.create(UPDATE_TEAM_SUCCESS.getMessage(), this.updateTeamUserCase.updateTeam(updateTeamRequest, user.getSocialId(), teamId)));
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/team/presentation/constant/TeamResponseMessage.java
+++ b/src/main/java/com/moing/backend/domain/team/presentation/constant/TeamResponseMessage.java
@@ -10,6 +10,7 @@ public enum TeamResponseMessage {
     GET_TEAM_SUCCESS("홈 화면에서 내 소모임을 모두 조회했습니다."),
     SIGNIN_TEAM_SUCCESS("소모임에 가입하였습니다"),
     DISBAND_TEAM_SUCCESS("[소모임장 권한] 소모임을 강제 종료했습니다."),
+    UPDATE_TEAM_SUCCESS("[소모임장 권한] 소모임을 수정했습니다"),
     WITHDRAW_TEAM_SUCCESS("[소모임원 권한] 소모임을 탈퇴하였습니다"),
     SEND_APPROVAL_ALARM_SUCCESS("소모임 승인 알림을 보냈습니다."),
     SEND_REJECTION_ALARM_SUCCESS("소모임 반려 알림을 보냈습니다.");

--- a/src/main/java/com/moing/backend/global/config/security/jwt/TokenUtil.java
+++ b/src/main/java/com/moing/backend/global/config/security/jwt/TokenUtil.java
@@ -109,7 +109,10 @@ public class TokenUtil implements InitializingBean {
         Member member = memberQueryService.getMemberBySocialId(socialId);
 
         // socialId 에 해당하는 refreshToken redis 에서 가져오기
-        String storedRefreshToken = redisUtil.findById(socialId).orElseThrow(() -> new NotFoundRefreshToken());
+        String storedRefreshToken = redisUtil.findById(socialId).orElseThrow(NotFoundRefreshToken::new);
+
+        //가져온 refeshToken이랑 입력한 refeshToken이랑 비교
+        if(storedRefreshToken == null || !storedRefreshToken.equals(token)) throw new NotFoundRefreshToken();
 
         // Token 생성
         TokenInfoResponse newToken = createToken(member, true);

--- a/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
@@ -2,10 +2,8 @@ package com.moing.backend.domain.team.presentation;
 
 import com.moing.backend.config.CommonControllerTest;
 import com.moing.backend.domain.team.application.dto.request.CreateTeamRequest;
-import com.moing.backend.domain.team.application.dto.response.CreateTeamResponse;
-import com.moing.backend.domain.team.application.dto.response.DeleteTeamResponse;
-import com.moing.backend.domain.team.application.dto.response.GetTeamResponse;
-import com.moing.backend.domain.team.application.dto.response.TeamBlock;
+import com.moing.backend.domain.team.application.dto.request.UpdateTeamRequest;
+import com.moing.backend.domain.team.application.dto.response.*;
 import com.moing.backend.domain.team.application.service.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,7 +22,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TeamController.class)
@@ -33,13 +32,14 @@ public class TeamControllerTest extends CommonControllerTest {
     private CreateTeamUserCase createTeamService;
     @MockBean
     private GetTeamUserCase getTeamUserCase;
-
     @MockBean
     private DisbandTeamUserCase disbandTeamUserCase;
     @MockBean
     private WithdrawTeamUserCase withdrawTeamUserCase;
     @MockBean
     private SignInTeamUserCase signInTeamUserCase;
+    @MockBean
+    private UpdateTeamUserCase updateTeamUserCase;
 
     @Test
     public void create_team() throws Exception {
@@ -270,6 +270,62 @@ public class TeamControllerTest extends CommonControllerTest {
                                         fieldWithPath("isSuccess").description("true"),
                                         fieldWithPath("message").description("소모임에 가입하였습니다."),
                                         fieldWithPath("data.teamId").description("가입한 소모임 id")
+                                )
+                        )
+                );
+    }
+
+
+    @Test
+    public void update_team() throws Exception {
+
+        // given
+        Long teamId = 1L;
+        UpdateTeamRequest input = UpdateTeamRequest.builder()
+                .name("수정 후 팀 이름")
+                .introduction("수정 후 소개")
+                .profileImgUrl("수정 후 프로필 이미지")
+                .build();
+
+
+        String body = objectMapper.writeValueAsString(input);
+
+        UpdateTeamResponse output = UpdateTeamResponse.builder()
+                .teamId(1L)
+                .build();
+
+        given(updateTeamUserCase.updateTeam(any(), any(), any())).willReturn(output);
+
+
+        //when
+        ResultActions actions = mockMvc.perform(RestDocumentationRequestBuilders.
+                put("/api/team/{teamId}", teamId)
+                .header("Authorization", "Bearer ACCESS_TOKEN")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        );
+
+
+        //then
+        actions
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName("Authorization").description("접근 토큰")
+                                ),
+                                pathParameters(
+                                        parameterWithName("teamId").description("팀 아이디")
+                                ),
+                                requestFields(
+                                        fieldWithPath("name").description("변경 후 소모임 이름"),
+                                        fieldWithPath("introduction").description("변경 후 소모임 소개글"),
+                                        fieldWithPath("profileImgUrl").description("변경 후 소모임 대표 사진")
+                                ),
+                                responseFields(
+                                        fieldWithPath("isSuccess").description("true"),
+                                        fieldWithPath("message").description("소모임을 수정했습니다."),
+                                        fieldWithPath("data.teamId").description("수정한 teamId")
                                 )
                         )
                 );


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- 소모임 수정 API 구현
- memberId로 List<Long> teamId가져오기

## 변경 사항
https://github.com/Modagbul/MOING_Server_Release/blob/8e87ca56a5d758b3ba3f844b59746ec487d36615/src/main/java/com/moing/backend/domain/team/presentation/TeamController.java#L88-L98

https://github.com/Modagbul/MOING_Server_Release/blob/8e87ca56a5d758b3ba3f844b59746ec487d36615/src/main/java/com/moing/backend/domain/team/domain/service/TeamGetService.java#L24-L26

## 코드 리뷰 시 참고 사항
요청 메서드는
team> domain > service > TeamGetSErvice에 있슴니당! 

## 테스트 결과
