### PR TITLE
feat: 마이페이지 조회 및 소모임 생성 에러 처리 추가

### DIFF
--- a/src/docs/asciidoc/Mypage-API.adoc
+++ b/src/docs/asciidoc/Mypage-API.adoc
@@ -11,6 +11,10 @@ operation::mypage-controller-test/sign_out[snippets='http-request,http-response,
 === Mypage 회원탈퇴
 operation::mypage-controller-test/withdraw[snippets='http-request,request-fields,http-response,response-fields']
 
+[[Mypage-전체-조회]]
+=== Mypage 전체 조회
+operation::mypage-controller-test/get_mypage[snippets='http-request,http-response,response-fields']
+
 [[Mypage-프로필-조회]]
 === Mypage 프로필 조회
 operation::mypage-controller-test/get_profile[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/moing/backend/domain/board/domain/repository/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/board/domain/repository/BoardCustomRepositoryImpl.java
@@ -70,16 +70,18 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository {
     public Integer findUnReadBoardNum(Long teamId, Long memberId) {
         // 전체 게시글 수
         Long allBoards = queryFactory
-                .selectFrom(board)
+                .select(board.count())
+                .from(board)
                 .where(board.team.teamId.eq(teamId))
-                .fetchCount();
+                .fetchFirst();
 
         // 멤버가 읽은 게시글 수
         Long readBoards = queryFactory
-                .selectFrom(boardRead)
+                .select(boardRead.count())
+                .from(boardRead)
                 .where(boardRead.member.memberId.eq(memberId))
                 .where(boardRead.board.team.teamId.eq(teamId))
-                .fetchCount();
+                .fetchFirst();
 
         return Math.toIntExact(allBoards - readBoards);
     }

--- a/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageResponse.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageResponse.java
@@ -1,0 +1,23 @@
+package com.moing.backend.domain.mypage.application.dto.response;
+
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.team.domain.constant.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class GetMyPageResponse {
+    private String profileImage;
+    private String nickName;
+    private String introduction;
+    private List<Category> categories=new ArrayList<>();
+    private List<GetMyPageTeamBlock> getMyPageTeamBlocks = new ArrayList<>();
+}

--- a/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageTeamBlock.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageTeamBlock.java
@@ -1,0 +1,14 @@
+package com.moing.backend.domain.mypage.application.dto.response;
+
+import com.moing.backend.domain.team.domain.constant.Category;
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class GetMyPageTeamBlock {
+    private Long teamId;
+    private String teamName;
+    private Category category;
+}

--- a/src/main/java/com/moing/backend/domain/mypage/application/mapper/MyPageMapper.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/mapper/MyPageMapper.java
@@ -1,0 +1,25 @@
+package com.moing.backend.domain.mypage.application.mapper;
+
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageResponse;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
+import com.moing.backend.domain.team.domain.constant.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MyPageMapper {
+
+    public GetMyPageResponse toGetMyPageResponse(Member member, List<Category> categories, List<GetMyPageTeamBlock> blocks) {
+        return GetMyPageResponse.builder()
+                .profileImage(member.getProfileImage())
+                .nickName(member.getNickName())
+                .introduction(member.getIntroduction())
+                .categories(categories)
+                .getMyPageTeamBlocks(blocks)
+                .build();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/mypage/application/service/GetMyPageUserCase.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/service/GetMyPageUserCase.java
@@ -1,0 +1,40 @@
+package com.moing.backend.domain.mypage.application.service;
+
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.member.domain.service.MemberGetService;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageResponse;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
+import com.moing.backend.domain.mypage.application.mapper.MyPageMapper;
+import com.moing.backend.domain.team.domain.constant.Category;
+import com.moing.backend.domain.team.domain.service.TeamGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GetMyPageUserCase {
+
+    private final MemberGetService memberGetService;
+    private final TeamGetService teamGetService;
+    private final MyPageMapper myPageMapper;
+
+    public GetMyPageResponse getMyPageResponse(String socialId) {
+        Member member = memberGetService.getMemberBySocialId(socialId);
+        List<GetMyPageTeamBlock> getMyPageTeamBlocks = teamGetService.getMyPageTeamBlockByMemberId(member.getMemberId());
+        return myPageMapper.toGetMyPageResponse(member, calculateCategory(getMyPageTeamBlocks), getMyPageTeamBlocks);
+    }
+
+    private List<Category> calculateCategory(List<GetMyPageTeamBlock> getMyPageTeamBlocks) {
+        return getMyPageTeamBlocks.stream()
+                .map(GetMyPageTeamBlock::getCategory)
+                .distinct()
+                .limit(2)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/moing/backend/domain/mypage/presentation/MyPageController.java
+++ b/src/main/java/com/moing/backend/domain/mypage/presentation/MyPageController.java
@@ -3,11 +3,9 @@ package com.moing.backend.domain.mypage.presentation;
 import com.moing.backend.domain.mypage.application.dto.request.UpdateProfileRequest;
 import com.moing.backend.domain.mypage.application.dto.request.WithdrawRequest;
 import com.moing.backend.domain.mypage.application.dto.response.GetAlarmResponse;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageResponse;
 import com.moing.backend.domain.mypage.application.dto.response.GetProfileResponse;
-import com.moing.backend.domain.mypage.application.service.AlarmUserCase;
-import com.moing.backend.domain.mypage.application.service.ProfileUserCase;
-import com.moing.backend.domain.mypage.application.service.SignOutUserCase;
-import com.moing.backend.domain.mypage.application.service.WithdrawUserCase;
+import com.moing.backend.domain.mypage.application.service.*;
 import com.moing.backend.global.config.security.dto.User;
 import com.moing.backend.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
@@ -28,8 +26,9 @@ public class MyPageController {
     private final WithdrawUserCase withdrawService;
     private final ProfileUserCase profileUserCase;
     private final AlarmUserCase alarmUserCase;
+    private final GetMyPageUserCase getMyPageUserCase;
 
-    //TODO 마이페이지 조회, 알림설정 수정
+    //TODO 알림설정 수정
 
     /**
      * 로그아웃
@@ -52,6 +51,16 @@ public class MyPageController {
                                                     @Valid @RequestBody WithdrawRequest withdrawRequest) {
         this.withdrawService.withdraw(user.getSocialId(), withdrawRequest);
         return ResponseEntity.ok(SuccessResponse.create(WITHDRAWAL_SUCCESS.getMessage()));
+    }
+
+    /**
+     * 마이페이지 조회
+     * [GET] api/mypage
+     * 작성자: 김민수
+     */
+    @GetMapping
+    public ResponseEntity<SuccessResponse<GetMyPageResponse>> getMyPage(@AuthenticationPrincipal User user){
+        return ResponseEntity.ok(SuccessResponse.create(GET_MYPAGE_SUCCESS.getMessage(), this.getMyPageUserCase.getMyPageResponse(user.getSocialId())));
     }
 
     /**

--- a/src/main/java/com/moing/backend/domain/mypage/presentation/constant/MypageResponseMessage.java
+++ b/src/main/java/com/moing/backend/domain/mypage/presentation/constant/MypageResponseMessage.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum MypageResponseMessage {
     SIGN_OUT_SUCCESS("로그아웃을 했습니다"),
     WITHDRAWAL_SUCCESS("회원탈퇴를 했습니다"),
+    GET_MYPAGE_SUCCESS("마이페이지를 조회했습니다"),
     GET_PROFILE_SUCCESS("프로필을 조회했습니다"),
     UPDATE_PROFILE_SUCCESS("프로필을 수정했습니다"),
     GET_ALARM_SUCCESS("알람 정보를 조회했습니다"),

--- a/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepository.java
@@ -1,5 +1,6 @@
 package com.moing.backend.domain.team.domain.repository;
 
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
 import com.moing.backend.domain.team.application.dto.response.GetTeamDetailResponse;
 import com.moing.backend.domain.team.application.dto.response.GetTeamResponse;
 import com.moing.backend.domain.team.domain.entity.Team;
@@ -11,4 +12,5 @@ public interface TeamCustomRepository {
     GetTeamResponse findTeamByMemberId(Long memberId);
     Optional<Team> findTeamByTeamId(Long TeamId);
     List<Long> findTeamIdByMemberId(Long memberId);
+    List<GetMyPageTeamBlock> findMyPageTeamByMemberId(Long memberId);
 }

--- a/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepositoryImpl.java
@@ -1,14 +1,15 @@
 package com.moing.backend.domain.team.domain.repository;
 
-import com.moing.backend.domain.member.domain.entity.QMember;
-import com.moing.backend.domain.team.application.dto.response.*;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
+import com.moing.backend.domain.team.application.dto.response.GetTeamResponse;
+import com.moing.backend.domain.team.application.dto.response.QTeamBlock;
+import com.moing.backend.domain.team.application.dto.response.TeamBlock;
 import com.moing.backend.domain.team.domain.constant.ApprovalStatus;
 import com.moing.backend.domain.team.domain.entity.Team;
-import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -56,6 +57,19 @@ public class TeamCustomRepositoryImpl implements TeamCustomRepository {
                 .where(team.isDeleted.eq(false) // 강제종료되지 않았거나
                         .or(team.deletionTime.after(threeDaysAgo))) // 강제종료된 경우 3일이 지나지 않았다면
                 .orderBy(team.approvalTime.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<GetMyPageTeamBlock> findMyPageTeamByMemberId(Long memberId) {
+        return queryFactory
+                .select(Projections.constructor(GetMyPageTeamBlock.class,
+                        team.teamId, team.name, team.category))
+                .from(teamMember)
+                .innerJoin(teamMember.team, team)
+                .on(teamMember.member.memberId.eq(memberId))
+                .where(team.approvalStatus.eq(ApprovalStatus.APPROVAL)) // 승인 되었고
+                .orderBy(team.missions.size().desc())
                 .fetch();
     }
 

--- a/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/repository/TeamCustomRepositoryImpl.java
@@ -56,6 +56,7 @@ public class TeamCustomRepositoryImpl implements TeamCustomRepository {
                 .where(teamMember.isDeleted.eq(false)) // 탈퇴하지 않았다면
                 .where(team.isDeleted.eq(false) // 강제종료되지 않았거나
                         .or(team.deletionTime.after(threeDaysAgo))) // 강제종료된 경우 3일이 지나지 않았다면
+                .groupBy(team.teamId)
                 .orderBy(team.approvalTime.asc())
                 .fetch();
     }
@@ -70,6 +71,7 @@ public class TeamCustomRepositoryImpl implements TeamCustomRepository {
                 .on(teamMember.member.memberId.eq(memberId))
                 .where(team.approvalStatus.eq(ApprovalStatus.APPROVAL)) // 승인 되었고
                 .orderBy(team.missions.size().desc())
+                .groupBy(team.teamId)
                 .fetch();
     }
 
@@ -92,6 +94,7 @@ public class TeamCustomRepositoryImpl implements TeamCustomRepository {
                         .or(team.deletionTime.isNotNull()
                         .or(team.deletionTime.after(threeDaysAgo)))) // 강제종료된 경우 3일이 지나지 않았다면
                 .orderBy(team.approvalTime.asc())
+                .groupBy(team.teamId)
                 .fetch();
     }
 

--- a/src/main/java/com/moing/backend/domain/team/domain/service/TeamGetService.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/service/TeamGetService.java
@@ -1,6 +1,7 @@
 package com.moing.backend.domain.team.domain.service;
 
 import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
 import com.moing.backend.domain.team.application.dto.response.GetTeamResponse;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.team.domain.repository.TeamRepository;
@@ -27,5 +28,9 @@ public class TeamGetService {
 
     public Team getTeamByTeamId(Long teamId){
         return teamRepository.findTeamByTeamId(teamId).orElseThrow(()->new NotFoundByTeamIdException());
+    }
+
+    public List<GetMyPageTeamBlock> getMyPageTeamBlockByMemberId(Long memberId){
+        return teamRepository.findMyPageTeamByMemberId(memberId);
     }
 }

--- a/src/main/java/com/moing/backend/domain/team/exception/AlreadyJoinTeamException.java
+++ b/src/main/java/com/moing/backend/domain/team/exception/AlreadyJoinTeamException.java
@@ -1,0 +1,11 @@
+package com.moing.backend.domain.team.exception;
+
+import com.moing.backend.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyJoinTeamException extends TeamException{
+    public AlreadyJoinTeamException(){
+        super(ErrorCode.ALREADY_JOIN_ERROR,
+                HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/moing/backend/domain/team/exception/AlreadyWithdrawTeamException.java
+++ b/src/main/java/com/moing/backend/domain/team/exception/AlreadyWithdrawTeamException.java
@@ -1,0 +1,11 @@
+package com.moing.backend.domain.team.exception;
+
+import com.moing.backend.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyWithdrawTeamException extends TeamException{
+    public AlreadyWithdrawTeamException(){
+        super(ErrorCode.ALREADY_WITHDRAW_ERROR,
+                HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
@@ -66,6 +66,7 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
                 .innerJoin(teamMember.team, team) // innerJoin을 사용하여 최적화
                 .where(teamMember.team.teamId.eq(teamId) // where 절을 하나로 합침
                         .and(teamMember.isDeleted.eq(false)))
+                .groupBy(teamMember.member.memberId)
                 .fetch();
     }
 }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberSaveService.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberSaveService.java
@@ -2,20 +2,36 @@ package com.moing.backend.domain.teamMember.domain.service;
 
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.domain.team.exception.AlreadyJoinTeamException;
+import com.moing.backend.domain.team.exception.AlreadyWithdrawTeamException;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.moing.backend.domain.teamMember.domain.repository.TeamMemberRepository;
 import com.moing.backend.global.annotation.DomainService;
 import lombok.RequiredArgsConstructor;
 
+import javax.transaction.Transactional;
+import java.util.Optional;
+
 @DomainService
 @RequiredArgsConstructor
+@Transactional
 public class TeamMemberSaveService {
     private final TeamMemberRepository teamMemberRepository;
     public void addTeamMember(Team team, Member member){
-        TeamMember teamMember=new TeamMember();
-        teamMember.updateMember(member);
-        teamMember.updateTeam(team);
-        team.addTeamMember();
-        this.teamMemberRepository.save(teamMember);
+        Optional<TeamMember> existingTeamMemberOpt = teamMemberRepository.findTeamMemberByTeamAndMember(team, member);
+
+        TeamMember teamMember = existingTeamMemberOpt.orElseGet(() -> {
+            TeamMember newMember = new TeamMember();
+            newMember.updateMember(member);
+            newMember.updateTeam(team);
+            team.addTeamMember();
+            return teamMemberRepository.save(newMember);
+        });
+
+        if (teamMember.isDeleted()) {
+            throw new AlreadyWithdrawTeamException();
+        } else {
+            throw new AlreadyJoinTeamException();
+        }
     }
 }

--- a/src/main/java/com/moing/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/moing/backend/global/response/ErrorCode.java
@@ -39,6 +39,8 @@ public enum ErrorCode {
     //팀 관련 에러 코드
     NOT_FOUND_BY_TEAM_ID_ERROR("T0001", "해당 teamId인 팀이 존재하지 않습니다."),
     NOT_AUTH_BY_TEAM_ERROR("T0002","권한이 없습니다."),
+    ALREADY_WITHDRAW_ERROR("T0003","이미 탈퇴한 회원입니다."),
+    ALREADY_JOIN_ERROR("T0004","이미 가입한 회원입니다."),
 
     //게시글 관련 에러 코드
     NOT_FOUND_BY_BOARD_ID_ERROR("B0001","해당 boardId인 게시글이 존재하지 않습니다."),

--- a/src/test/java/com/moing/backend/domain/mypage/presentation/MypageControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/mypage/presentation/MypageControllerTest.java
@@ -3,17 +3,20 @@ package com.moing.backend.domain.mypage.presentation;
 import com.moing.backend.config.CommonControllerTest;
 import com.moing.backend.domain.mypage.application.dto.request.UpdateProfileRequest;
 import com.moing.backend.domain.mypage.application.dto.request.WithdrawRequest;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageResponse;
+import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
 import com.moing.backend.domain.mypage.application.dto.response.GetProfileResponse;
-import com.moing.backend.domain.mypage.application.service.AlarmUserCase;
-import com.moing.backend.domain.mypage.application.service.ProfileUserCase;
-import com.moing.backend.domain.mypage.application.service.SignOutUserCase;
-import com.moing.backend.domain.mypage.application.service.WithdrawUserCase;
+import com.moing.backend.domain.mypage.application.service.*;
 import com.moing.backend.domain.team.application.dto.response.CreateTeamResponse;
+import com.moing.backend.domain.team.domain.constant.Category;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -36,6 +39,9 @@ public class MypageControllerTest extends CommonControllerTest {
 
     @MockBean
     private AlarmUserCase alarmUserCase;
+
+    @MockBean
+    private GetMyPageUserCase getMyPageUserCase;
 
     @Test
     public void sign_out() throws Exception {
@@ -96,6 +102,61 @@ public class MypageControllerTest extends CommonControllerTest {
                                 responseFields(
                                         fieldWithPath("isSuccess").description("true"),
                                         fieldWithPath("message").description("회원탈퇴를 했습니다")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    public void get_mypage() throws Exception{
+        //given
+        List<Category> categoryList=new ArrayList<>();
+        categoryList.add(Category.SPORTS);
+
+        List<GetMyPageTeamBlock> getMyPageTeamBlocks=new ArrayList<>();
+        GetMyPageTeamBlock blocks= GetMyPageTeamBlock.builder()
+                .teamId(1L)
+                .teamName("소모임이름")
+                .category(Category.SPORTS)
+                .build();
+        getMyPageTeamBlocks.add(blocks);
+
+        GetMyPageResponse output = GetMyPageResponse.builder()
+                .profileImage("PROFILE_IMAGE_URL")
+                .introduction("INTRODUCTION")
+                .nickName("NICKNAME")
+                .categories(categoryList)
+                .getMyPageTeamBlocks(getMyPageTeamBlocks)
+                .build();
+
+        given(getMyPageUserCase.getMyPageResponse(any())).willReturn(output);
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                get("/api/mypage")
+                        .header("Authorization", "Bearer ACCESS_TOKEN")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+
+        //then
+        actions
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName("Authorization").description("접근 토큰")
+                                ),
+                                responseFields(
+                                        fieldWithPath("isSuccess").description("true"),
+                                        fieldWithPath("message").description("마이페이지를 조회했습니다"),
+                                        fieldWithPath("data.profileImage").description("프로필 이미지 URL"),
+                                        fieldWithPath("data.nickName").description("닉네임"),
+                                        fieldWithPath("data.introduction").description("한줄 소개"),
+                                        fieldWithPath("data.categories[0]").description("내 열정의 불 해시태그"),
+                                        fieldWithPath("data.getMyPageTeamBlocks[0].teamId").description("소모임 아이디"),
+                                        fieldWithPath("data.getMyPageTeamBlocks[0].teamName").description("소모임 이름"),
+                                        fieldWithPath("data.getMyPageTeamBlocks[0].category").description("소모임 카테고리")
                                 )
                         )
                 );


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- 마이페이지 조회
- 소모임 생성 시 탈퇴 회원 , 이미 가입한 회원은 가입할 수 없게 막기

## 변경 사항
1. 마이페이지 조회
https://github.com/Modagbul/MOING_Server_Release/blob/9c3a141214e79a5977528bb2126698a298d8145a/src/main/java/com/moing/backend/domain/mypage/presentation/MyPageController.java#L56-L64

2. 소모임 생성 에러 처리 추가
https://github.com/Modagbul/MOING_Server_Release/blob/9c3a141214e79a5977528bb2126698a298d8145a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberSaveService.java#L18-L37

## 코드 리뷰 시 참고 사항

## 테스트 결과
https://github.com/Modagbul/MOING_Server_Release/blob/d413ef91ca9ba8649884ec05b6bd37f610c256d9/src/test/java/com/moing/backend/domain/mypage/presentation/MypageControllerTest.java#L110-L163
