### PR TITLE
소모임 수정 전 조회 API 만들기

### DIFF
--- a/src/docs/asciidoc/Auth-API.adoc
+++ b/src/docs/asciidoc/Auth-API.adoc
@@ -2,7 +2,7 @@
 = Auth API
 
 [[Auth-Kako-소셜-로그인]]
-=== Auth Kakao 소셜 로그인
+== Auth Kakao 소셜 로그인
 operation::auth-controller-test/kakao_소셜_로그인_회원가입_전[snippets='http-request,request-fields']
 operation::auth-controller-test/kakao_소셜_로그인_회원가입_전[snippets='http-response,response-fields']
 operation::auth-controller-test/kakao_소셜_로그인_회원가입_후[snippets='http-response,response-fields']
@@ -10,14 +10,14 @@ operation::auth-controller-test/kakao_소셜_로그인_회원가입_후[snippets
 ---
 
 [[Auth-Apple-소셜-로그인]]
-=== Auth Apple 소셜 로그인
+== Auth Apple 소셜 로그인
 operation::auth-controller-test/apple_소셜_로그인_회원가입_전[snippets='http-request,request-fields']
 operation::auth-controller-test/apple_소셜_로그인_회원가입_전[snippets='http-response,response-fields']
 operation::auth-controller-test/apple_소셜_로그인_회원가입_후[snippets='http-response,response-fields']
 
 
 [[Auth-Google-소셜-로그인]]
-=== Auth Google 소셜 로그인
+== Auth Google 소셜 로그인
 operation::auth-controller-test/google_소셜_로그인_회원가입_전[snippets='http-request,request-fields']
 operation::auth-controller-test/google_소셜_로그인_회원가입_전[snippets='http-response,response-fields']
 operation::auth-controller-test/google_소셜_로그인_회원가입_후[snippets='http-response,response-fields']
@@ -35,15 +35,15 @@ operation::auth-controller-test/sign_up[snippets='http-request,request-fields,ht
 
 
 [[Auth-토큰-재발급]]
-=== Auth 토큰 재발급
+== Auth 토큰 재발급
 operation::auth-controller-test/reissue_token[snippets='http-request,http-response,response-fields']
 
 [[Auth-닉네임-검사]]
-=== Auth 닉네임 중복검사 요청
+== Auth 닉네임 중복검사 요청
 operation::auth-controller-test/check_nickname_중복o[snippets='http-request,path-parameters']
 
-=== Auth 닉네임 중복인 경우
+== Auth 닉네임 중복인 경우
 operation::auth-controller-test/check_nickname_중복o[snippets='http-response,response-fields']
 
-=== Auth 닉네임 중복이 아닌 경우
+== Auth 닉네임 중복이 아닌 경우
 operation::auth-controller-test/check_nickname_중복x[snippets='http-response,response-fields']

--- a/src/docs/asciidoc/Board-API.adoc
+++ b/src/docs/asciidoc/Board-API.adoc
@@ -2,26 +2,26 @@
 = Board API
 
 [[Board-게시글-생성]]
-=== Board 게시글 생성
+== Board 게시글 생성
 operation::board-controller-test/create_board[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 ---
 
 [[Board-게시글-수정]]
-=== Board 게시글 수정
+== Board 게시글 수정
 operation::board-controller-test/update_board[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 ---
 
 [[Board-게시글-삭제]]
-=== Board 게시글 삭제
-operation::board-controller-test/delete_board[snippets='http-request,path-parameters,request-fields,response-fields']
+== Board 게시글 삭제
+operation::board-controller-test/delete_board[snippets='http-request,path-parameters,response-fields']
 ---
 
 [[Board-게시글-전체-조회]]
-=== Board 게시글 전체 조회
+== Board 게시글 전체 조회
 operation::board-controller-test/get_board_all[snippets='http-request,path-parameters,http-response,response-fields']
 ---
 
 [[Board-게시글-상제-조회]]
-=== Board 게시글 상세 조회
+== Board 게시글 상세 조회
 operation::board-controller-test/get_board_detail[snippets='http-request,path-parameters,http-response,response-fields']
 ---

--- a/src/docs/asciidoc/BoardComment_API.adoc
+++ b/src/docs/asciidoc/BoardComment_API.adoc
@@ -2,16 +2,16 @@
 = Board Comment API
 
 [[Board-Comment-댓글-생성]]
-=== Board Comment 댓글 생성
+== Board Comment 댓글 생성
 operation::board-comment-controller-test/create_board_comment[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 ---
 
 [[Board-Comment-댓글-삭제]]
-=== Board Comment 댓글 삭제
-operation::board-comment-controller-test/delete_board_comment[snippets='http-request,path-parameters,request-fields,response-fields']
+== Board Comment 댓글 삭제
+operation::board-comment-controller-test/delete_board_comment[snippets='http-request,path-parameters,response-fields']
 ---
 
 [[Board-Comment-댓글-전체-조회]]
-=== Board Comment 댓글 전체 조회
+== Board Comment 댓글 전체 조회
 operation::board-comment-controller-test/get_board_comment_all[snippets='http-request,path-parameters,http-response,response-fields']
 ---

--- a/src/docs/asciidoc/Fire-API.adoc
+++ b/src/docs/asciidoc/Fire-API.adoc
@@ -4,13 +4,13 @@
 = Fire API
 
 [[Fire-불던지기]]
-=== 불 던지기
-operation::fire-controller-test/불_던지기[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 불 던지기
+operation::fire-controller-test/불_던지기[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 [[Fire-불던질사람조회]]
-=== 불 던질 사람 조회
-operation::fire-controller-test/불_던질_사람_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 불 던질 사람 조회
+operation::fire-controller-test/불_던질_사람_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 

--- a/src/docs/asciidoc/Image-API.adoc
+++ b/src/docs/asciidoc/Image-API.adoc
@@ -2,7 +2,7 @@
 = Image API
 
 [[Presigned-Url-발급]]
-=== Presigned Url 발급
+== Presigned Url 발급
 operation::image-controller-test/create_presigned_url[snippets='http-request,http-response,request-fields,response-fields']
 
 === imageFileExtension

--- a/src/docs/asciidoc/Mission-API.adoc
+++ b/src/docs/asciidoc/Mission-API.adoc
@@ -4,26 +4,26 @@
 = Mission API
 
 [[Mission-생성]]
-=== Mission 생성
+== Mission 생성
 operation::mission-controller-test/미션_생성[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 ---
 
 [[Mission-조회]]
-=== Mission 조회
-operation::mission-controller-test/미션_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== Mission 조회
+operation::mission-controller-test/미션_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 
 [[Mission-수정]]
-=== Mission 수정
+== Mission 수정
 operation::mission-controller-test/미션_수정[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 ---
 
 [[Mission-삭제]]
-=== Mission 삭제
-operation::mission-controller-test/미션_삭제[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== Mission 삭제
+operation::mission-controller-test/미션_삭제[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 

--- a/src/docs/asciidoc/MissionArchive-API.adoc
+++ b/src/docs/asciidoc/MissionArchive-API.adoc
@@ -4,37 +4,37 @@
 = MissionArchive API
 
 [[MissionArchive-인증하기]]
-=== 미션 인증하기
+== 미션 인증하기
 operation::mission-archive-controller-test/미션_인증하기[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 ---
 
 [[MissionArchive-재인증하기]]
-=== 미션 재인증하기
+== 미션 재인증하기
 operation::mission-archive-controller-test/미션_재인증하기[snipipets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 ---
 
 [[MissionArchive-나의미션인증조회]]
-=== 나의 미션 인증 조회
-operation::mission-archive-controller-test/나의_미션_인증_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 나의 미션 인증 조회
+operation::mission-archive-controller-test/나의_미션_인증_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 
 [[MissionArchive-모임원미션인증조회]]
-=== 모임원 미션 인증 조회
-operation::mission-archive-controller-test/모임원_미션_인증_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 모임원 미션 인증 조회
+operation::mission-archive-controller-test/모임원_미션_인증_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 
 [[MissionArchive-인증성공인원조회]]
-=== 인증 성공 인원 조회 ( n/n명 )
-operation::mission-archive-controller-test/인증_성공_인원_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 인증 성공 인원 조회 ( n/n명 )
+operation::mission-archive-controller-test/인증_성공_인원_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 
 [[MissionArchive-미션인증물좋아요]]
-=== 미션 인증물 좋아요
+== 미션 인증물 좋아요
 operation::mission-archive-controller-test/미션_인증물_좋아요[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 ---

--- a/src/docs/asciidoc/MissionBoard-API.adoc
+++ b/src/docs/asciidoc/MissionBoard-API.adoc
@@ -4,25 +4,25 @@
 = MissionBoard API
 
 [[MissionBoard-단일미션인증조회]]
-=== 단일 미션 인증 조회
-operation::mission-board-controller-test/단일_미션_인증_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 단일 미션 인증 조회
+operation::mission-board-controller-test/단일_미션_인증_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 
 [[MissionBoard-반복미션인증조회]]
-=== 반복 미션 인증 조회
-operation::mission-board-controller-test/반복 미션 인증 조회[snipipets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 반복 미션 인증 조회
+operation::mission-board-controller-test/반복_미션_인증_조회[snipipets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 ---
 
 [[MissionBoard-나의미션인증조회]]
-=== 나의 미션 인증 조회
-operation::mission-archive-controller-test/나의_미션_인증_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 나의 미션 인증 조회
+operation::mission-archive-controller-test/나의_미션_인증_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---
 
 [[MissionBoard-종료된인증조회]]
-=== 종료된 인증 조회
-operation::mission-board-controller-test/종료된_인증_조회[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 종료된 인증 조회
+operation::mission-board-controller-test/종료된_인증_조회[snippets='http-request,path-parameters,http-response,response-fields']
 
 ---

--- a/src/docs/asciidoc/MissionGatherBoard-API.adoc
+++ b/src/docs/asciidoc/MissionGatherBoard-API.adoc
@@ -4,13 +4,12 @@
 = MissionBoard API
 
 [[MissionBoard-미션-모아보기-단일]]
-=== 미션_모아보기_단일_미션
-operation::mission-gather-controller-test/미션_모아보기_단일_미션[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
-
+== 미션_모아보기_단일_미션
+operation::mission-gather-controller-test/미션_모아보기_단일_미션[snippets='http-request,http-response,response-fields']
 ---
 
 [[MissionBoard-미션-모아보기-반복]]
-=== 미션_모아보기_반복_미션
-operation::mission-gather-controller-test/미션_모아보기_반복_미션[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+== 미션_모아보기_반복_미션
+operation::mission-gather-controller-test/미션_모아보기_반복_미션[snippets='http-request,http-response,response-fields']
 
 ---

--- a/src/docs/asciidoc/Mypage-API.adoc
+++ b/src/docs/asciidoc/Mypage-API.adoc
@@ -2,26 +2,26 @@
 = Mypage API
 
 [[Mypage-로그아웃]]
-=== Mypage 로그아웃
+== Mypage 로그아웃
 operation::mypage-controller-test/sign_out[snippets='http-request,http-response,response-fields']
 
 ---
 
 [[Mypage-회원탈퇴]]
-=== Mypage 회원탈퇴
+== Mypage 회원탈퇴
 operation::mypage-controller-test/withdraw[snippets='http-request,request-fields,http-response,response-fields']
 
 [[Mypage-전체-조회]]
-=== Mypage 전체 조회
+== Mypage 전체 조회
 operation::mypage-controller-test/get_mypage[snippets='http-request,http-response,response-fields']
 
 [[Mypage-프로필-조회]]
-=== Mypage 프로필 조회
+== Mypage 프로필 조회
 operation::mypage-controller-test/get_profile[snippets='http-request,http-response,response-fields']
 IMPORTANT: Response Fields (profileImage, nickName, introduction)이 "undef" 인 경우는 사용자가 아직 입력을 안 한 경우임
 
 [[Mypage-프로필-수정]]
-=== Mypage 프로필 수정
+== Mypage 프로필 수정
 operation::mypage-controller-test/update_profile[snippets='http-request,http-response,request-fields,response-fields']
 IMPORTANT: Request Fileds는 반드시 세 값이 모두 들어가야 하는 것이 아니고, 업데이트할 값만 입력해도 됨, 따라서 아래와 같은 예시 가능 +
 
@@ -36,11 +36,11 @@ Host: localhost:8080
 
 
 [[Mypage-알람설정_조회]]
-=== Mypage 알람설정 조회
+== Mypage 알람설정 조회
 operation::mypage-controller-test/get_alarm[snippets='http-request,http-response,response-fields']
 
 
 [[Mypage-알람설정_수정]]
-=== Mypage 알람설정 수정
+== Mypage 알람설정 수정
 operation::mypage-controller-test/update_alarm[snippets='http-request,http-response,request-parameters,response-fields']
 

--- a/src/docs/asciidoc/Team-API.adoc
+++ b/src/docs/asciidoc/Team-API.adoc
@@ -2,10 +2,10 @@
 = Team API
 
 [[Team-소모임-개설]]
-=== Team 소모임 개설
+== Team 소모임 개설
 operation::team-controller-test/create_team[snippets='http-request,request-fields,http-response,response-fields']
 
-=== Team Category
+== Team Category
 |===
 | Category | Description
 
@@ -30,25 +30,29 @@ operation::team-controller-test/create_team[snippets='http-request,request-field
 
 
 [[Team-소모임-가입]]
-=== Team 소모임 가입
+== Team 소모임 가입
 operation::team-controller-test/sign-in_team[snippets='http-request,path-parameters,http-response,response-fields']
 
 [[Team-소모임-조회]]
-=== Team 소모임 조회
+== Team 소모임 조회
 operation::team-controller-test/get_team[snippets='http-request,http-response,response-fields']
 
 [[Team-목표보드-조회]]
-=== Team 목표보드_소모임 단건_조회
+== Team 목표보드_소모임 단건_조회
 operation::team-controller-test/get_team_detail[snippets='http-request,path-parameters,http-response,response-fields']
 
 [[Team-소모임-수정]]
-=== Team 소모임 수정
+== Team 소모임 수정
 operation::team-controller-test/update_team[snippets='http-request,path-parameters,http-response,request-fields,response-fields']
 
+[[Team-소모임-수정전-조회]]
+== Team 소모임 수정 전 조회
+operation::team-controller-test/get_current_status[snippets='http-request,path-parameters,http-response,response-fields']
+
 [[Team-소모임-강제종료]]
-=== Team 소모임 강제종료
+== Team 소모임 강제종료
 operation::team-controller-test/disband_team[snippets='http-request,path-parameters,http-response,response-fields']
 
 [[Team-소모임-탈퇴]]
-=== Team 소모임원 강제종료
+== Team 소모임원 강제종료
 operation::team-controller-test/withdraw_team[snippets='http-request,path-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -3,7 +3,7 @@
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 2
+:toclevels: 1
 :sectlinks:
 
 include::Overview.adoc[]

--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/GetCurrentStatusResponse.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/GetCurrentStatusResponse.java
@@ -1,0 +1,17 @@
+package com.moing.backend.domain.team.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetCurrentStatusResponse {
+
+    private String name;
+
+    private String introduction;
+
+    private String profileImgUrl;
+}

--- a/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
+++ b/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
@@ -2,16 +2,12 @@ package com.moing.backend.domain.team.application.mapper;
 
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.request.CreateTeamRequest;
-import com.moing.backend.domain.team.application.dto.response.DeleteTeamResponse;
-import com.moing.backend.domain.team.application.dto.response.GetTeamDetailResponse;
-import com.moing.backend.domain.team.application.dto.response.TeamInfo;
-import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
+import com.moing.backend.domain.team.application.dto.response.*;
 import com.moing.backend.domain.team.domain.constant.ApprovalStatus;
 import com.moing.backend.domain.team.domain.constant.Category;
 import com.moing.backend.domain.team.domain.entity.Team;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
@@ -61,6 +57,14 @@ public class TeamMapper {
         long daysBetween = hoursBetween / 24;
 
         return daysBetween;
+    }
+
+    public GetCurrentStatusResponse toCurrentStatusResponse(Team team) {
+        return GetCurrentStatusResponse.builder()
+                .name(team.getName())
+                .introduction(team.getIntroduction())
+                .profileImgUrl(team.getProfileImgUrl())
+                .build();
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/team/application/service/GetTeamUserCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/GetTeamUserCase.java
@@ -3,6 +3,7 @@ package com.moing.backend.domain.team.application.service;
 import com.moing.backend.domain.board.domain.service.BoardGetService;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.member.domain.service.MemberGetService;
+import com.moing.backend.domain.team.application.dto.response.GetCurrentStatusResponse;
 import com.moing.backend.domain.team.application.dto.response.GetTeamDetailResponse;
 import com.moing.backend.domain.team.application.dto.response.GetTeamResponse;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
@@ -37,5 +38,10 @@ public class GetTeamUserCase {
         List<TeamMemberInfo> teamMemberInfoList = teamMemberGetService.getTeamMemberInfo(teamId);
         Team team = teamGetService.getTeamByTeamId(teamId);
         return teamMapper.toTeamDetailResponse(team, boardNum, teamMemberInfoList);
+    }
+
+    public GetCurrentStatusResponse getCurrentStatus(Long teamId) {
+        Team team=teamGetService.getTeamByTeamId(teamId);
+        return teamMapper.toCurrentStatusResponse(team);
     }
 }

--- a/src/main/java/com/moing/backend/domain/team/presentation/TeamController.java
+++ b/src/main/java/com/moing/backend/domain/team/presentation/TeamController.java
@@ -52,7 +52,7 @@ public class TeamController {
      * [GET] api/team/{teamId}
      * 작성자: 김민수
      */
-    @GetMapping("/{teamId}")
+    @GetMapping("/board/{teamId}")
     public ResponseEntity<SuccessResponse<GetTeamDetailResponse>> getTeamDetail(@AuthenticationPrincipal User user,
                                                                                 @PathVariable Long teamId) {
         return ResponseEntity.ok(SuccessResponse.create(GET_TEAM_DETAIL_SUCCESS.getMessage(), this.getTeamUserCase.getTeamDetailResponse(user.getSocialId(), teamId)));
@@ -102,6 +102,16 @@ public class TeamController {
                                                                           @AuthenticationPrincipal User user,
                                                                           @PathVariable Long teamId){
         return ResponseEntity.ok(SuccessResponse.create(UPDATE_TEAM_SUCCESS.getMessage(), this.updateTeamUserCase.updateTeam(updateTeamRequest, user.getSocialId(), teamId)));
+    }
+
+    /**
+     * 소모임 수정 전 조회
+     * [GET] api/team/{teamid}
+     */
+    @GetMapping("/{teamId}")
+    public ResponseEntity<SuccessResponse<GetCurrentStatusResponse>> getCurrentStatus(@AuthenticationPrincipal User user,
+                                                                                      @PathVariable Long teamId) {
+        return ResponseEntity.ok(SuccessResponse.create(GET_CURRENT_STATUS_SUCCESS.getMessage(), this.getTeamUserCase.getCurrentStatus(teamId)));
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/team/presentation/constant/TeamResponseMessage.java
+++ b/src/main/java/com/moing/backend/domain/team/presentation/constant/TeamResponseMessage.java
@@ -6,10 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum TeamResponseMessage {
-    CREATE_TEAM_SUCCESS("소모임을 생성하였습니다"),
+    CREATE_TEAM_SUCCESS("소모임을 생성하였습니다."),
     GET_TEAM_SUCCESS("홈 화면에서 내 소모임을 모두 조회했습니다."),
-    GET_TEAM_DETAIL_SUCCESS("목표보드를 조회했습니다"),
-    SIGNIN_TEAM_SUCCESS("소모임에 가입하였습니다"),
+    GET_TEAM_DETAIL_SUCCESS("목표보드를 조회했습니다."),
+    SIGNIN_TEAM_SUCCESS("소모임에 가입하였습니다."),
+    GET_CURRENT_STATUS_SUCCESS("소모임 수정 전 조회했습니다."),
     DISBAND_TEAM_SUCCESS("[소모임장 권한] 소모임을 강제 종료했습니다."),
     UPDATE_TEAM_SUCCESS("[소모임장 권한] 소모임을 수정했습니다"),
     WITHDRAW_TEAM_SUCCESS("[소모임원 권한] 소모임을 탈퇴하였습니다"),

--- a/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
@@ -206,7 +206,7 @@ public class TeamControllerTest extends CommonControllerTest {
 
         //when
         ResultActions actions = mockMvc.perform(RestDocumentationRequestBuilders.
-                get("/api/team/{teamId}", teamId)
+                get("/api/team/board/{teamId}", teamId)
                 .header("Authorization", "Bearer ACCESS_TOKEN")
                 .contentType(MediaType.APPLICATION_JSON)
         );
@@ -431,5 +431,49 @@ public class TeamControllerTest extends CommonControllerTest {
                 );
     }
 
+    @Test
+    public void get_current_status() throws Exception {
+
+        // given
+        Long teamId = 1L;
+
+        GetCurrentStatusResponse output = GetCurrentStatusResponse.builder()
+                .name("팀 이름")
+                .introduction("소개")
+                .profileImgUrl("프로필 이미지")
+                .build();
+
+        given(getTeamUserCase.getCurrentStatus(any())).willReturn(output);
+
+
+        //when
+        ResultActions actions = mockMvc.perform(RestDocumentationRequestBuilders.
+                get("/api/team/{teamId}", teamId)
+                .header("Authorization", "Bearer ACCESS_TOKEN")
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+
+        //then
+        actions
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName("Authorization").description("접근 토큰")
+                                ),
+                                pathParameters(
+                                        parameterWithName("teamId").description("팀 아이디")
+                                ),
+                                responseFields(
+                                        fieldWithPath("isSuccess").description("true"),
+                                        fieldWithPath("message").description("소모임을 수정했습니다."),
+                                        fieldWithPath("data.name").description("소모임 이름"),
+                                        fieldWithPath("data.introduction").description("소모임 소개글"),
+                                        fieldWithPath("data.profileImgUrl").description("소모임 대표 사진")
+                                )
+                        )
+                );
+    }
 
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- 소모임 수정 전 조회 API
- build시 adoc warning 안뜨게 수정
- 소모임 목표보드 API endpoint수정

## 변경 사항
1. 클라이언트의 요청으로 소모임 수정 전 조회 API를 추가
https://github.com/Modagbul/MOING_Server_Release/blob/33f239451822d35c1a8e20860f3662b1c6c7a471/src/main/java/com/moing/backend/domain/team/presentation/TeamController.java#L107-L115   

2. build시 adoc warning 기존에 뜬 이유
<img width="859" alt="image" src="https://github.com/Modagbul/MOING_Server_Release/assets/86006389/de9de2de-ce25-4a8c-b9d4-a0873805b7a7">
이렇게 없는 부분을 불러오려고 할 때 warning이 뜸 따라서 그 부분을 수정   
 

3. 소모임 수정 전 조회 API를 "/api/team/{teamId}"로 하면서 기존 소모임 목표보드 API를 "/api/team/board/{teamId}"로 수정했습니다.

## 코드 리뷰 시 참고 사항
위의 변경사항 확인 부탁드립니다~!

## 테스트 결과
https://github.com/Modagbul/MOING_Server_Release/blob/33f239451822d35c1a8e20860f3662b1c6c7a471/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java#L434-L477