### PR TITLE
feat : mission 관련 dto 객체 lombok 추가 및 API 문서 수정 /  팀별 미션 인증물 리턴

### DIFF
--- a/src/main/java/com/moing/backend/domain/mission/application/dto/req/MissionReq.java
+++ b/src/main/java/com/moing/backend/domain/mission/application/dto/req/MissionReq.java
@@ -1,10 +1,11 @@
 package com.moing.backend.domain.mission.application.dto.req;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
-@Getter
+@AllArgsConstructor
 @Builder
+@NoArgsConstructor
+@Getter
 public class MissionReq {
 
     private String title;

--- a/src/main/java/com/moing/backend/domain/mission/application/service/MissionGatherBoardUseCase.java
+++ b/src/main/java/com/moing/backend/domain/mission/application/service/MissionGatherBoardUseCase.java
@@ -5,6 +5,10 @@ import com.moing.backend.domain.member.domain.service.MemberGetService;
 import com.moing.backend.domain.mission.application.dto.res.GatherRepeatMissionRes;
 import com.moing.backend.domain.mission.application.dto.res.GatherSingleMissionRes;
 import com.moing.backend.domain.mission.domain.service.MissionQueryService;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
+import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
+import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.domain.team.domain.service.TeamGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +21,9 @@ import java.util.List;
 public class MissionGatherBoardUseCase {
 
     private final MissionQueryService missionQueryService;
+    private final MissionArchiveQueryService missionArchiveQueryService;
     private final MemberGetService memberGetService;
+    private final TeamGetService teamGetService;
 
     public List<GatherSingleMissionRes> getAllActiveSingleMissions(String userId) {
         Long memberId  = memberGetService.getMemberBySocialId(userId).getMemberId();
@@ -29,6 +35,15 @@ public class MissionGatherBoardUseCase {
         return missionQueryService.findAllRepeatMission(memberId);
 
     }
+
+    public List<MissionArchivePhotoRes> getArchivePhotoByTeamRes(String userId) {
+        Long memberId  = memberGetService.getMemberBySocialId(userId).getMemberId();
+
+        List<Long> teamIdByMemberId = teamGetService.getTeamIdByMemberId(memberId);
+
+        return missionArchiveQueryService.findTop5ArchivesByTeam(teamIdByMemberId);
+    }
+
 
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/req/MissionArchiveReq.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/req/MissionArchiveReq.java
@@ -1,12 +1,11 @@
 package com.moing.backend.domain.missionArchive.application.dto.req;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
-@Getter
-@Setter
+@AllArgsConstructor
 @Builder
+@NoArgsConstructor
+@Getter
 public class MissionArchiveReq {
 
     private String status;

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchivePhotoRes.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchivePhotoRes.java
@@ -5,11 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
+import java.util.List;
+
 @Builder
-@NoArgsConstructor
 @Getter
-public class MissionArchiveStatusRes {
-    private String total;
-    private String done;
+@NoArgsConstructor
+@AllArgsConstructor
+public class MissionArchivePhotoRes {
+    Long teamId;
+    List<String> photo;
 }

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchiveRes.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchiveRes.java
@@ -1,15 +1,13 @@
 package com.moing.backend.domain.missionArchive.application.dto.res;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.annotation.Nullable;
 import java.util.List;
-
+@AllArgsConstructor
 @Builder
+@NoArgsConstructor
 @Getter
-@Setter
 public class MissionArchiveRes {
 
     private Long archiveId;

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/PersonalArchiveRes.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/PersonalArchiveRes.java
@@ -1,12 +1,11 @@
 package com.moing.backend.domain.missionArchive.application.dto.res;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
-@Getter
-@Setter
+@AllArgsConstructor
 @Builder
+@NoArgsConstructor
+@Getter
 public class PersonalArchiveRes {
 
     private Long archiveId;

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveReadUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveReadUseCase.java
@@ -4,6 +4,7 @@ import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.member.domain.service.MemberGetService;
 import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.mission.domain.service.MissionQueryService;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveStatusRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.PersonalArchiveRes;
@@ -11,6 +12,7 @@ import com.moing.backend.domain.missionArchive.application.mapper.MissionArchive
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.team.domain.repository.TeamRepository;
+import com.moing.backend.domain.team.domain.service.TeamGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +29,7 @@ public class MissionArchiveReadUseCase {
     private final MemberGetService memberGetService;
     private final MissionQueryService missionQueryService;
     private final MissionArchiveQueryService missionArchiveQueryService;
-    private final TeamRepository teamRepository;
+    private final TeamGetService teamGetService;
 
 
     // 미션 인증 조회
@@ -35,7 +37,7 @@ public class MissionArchiveReadUseCase {
 
         Long memberId = memberGetService.getMemberBySocialId(userSocialId).getMemberId();
 
-        return MissionArchiveMapper.mapToMissionArchiveResList(missionArchiveQueryService.findMyArchive(memberId, missionId),memberId);
+        return MissionArchiveMapper.mapToMissionArchiveResList(missionArchiveQueryService.findMyArchive(memberId, missionId), memberId);
     }
 
     // 모두의 미션 인증 목록 조회
@@ -44,7 +46,7 @@ public class MissionArchiveReadUseCase {
         List<PersonalArchiveRes> personalArchives = new ArrayList<>();
 
         Long memberId = memberGetService.getMemberBySocialId(userSocialId).getMemberId();
-        return MissionArchiveMapper.mapToPersonalArchiveList(missionArchiveQueryService.findOthersArchive(memberId, missionId),memberId);
+        return MissionArchiveMapper.mapToPersonalArchiveList(missionArchiveQueryService.findOthersArchive(memberId, missionId), memberId);
     }
 
     public MissionArchiveStatusRes getMissionDoneStatus(Long missionId) {
@@ -57,6 +59,8 @@ public class MissionArchiveReadUseCase {
                 .build();
 
     }
+
+
 
 
 }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/constant/MissionArchiveResponseMessage.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/constant/MissionArchiveResponseMessage.java
@@ -15,7 +15,8 @@ public enum MissionArchiveResponseMessage {
     MISSION_ARCHIVE_PEOPLE_STATUS_SUCCESS("미션 인증 성공한 인원 상태 조회를 완료 했습니다."),
     ACTIVE_SINGLE_MISSION_SUCCESS("진행 중인 한번 인증 미션 조회를 완료 했습니다."),
     ACTIVE_REPEAT_MISSION_SUCCESS("진행 중인 반복 인증 미션 조회를 완료 했습니다."),
-    FINISH_ALL_MISSION_SUCCESS("종료된 미션 조회를 완료하였습니다.");
+    FINISH_ALL_MISSION_SUCCESS("종료된 미션 조회를 완료하였습니다."),
+    MISSION_ARCHIVE_BY_TEAM("팀별 미션 인증물 사진 조회를 완료했습니더.");
 
     private final String message;
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepository.java
@@ -1,9 +1,9 @@
 package com.moing.backend.domain.missionArchive.domain.repository;
 
 import com.moing.backend.domain.mission.application.dto.res.FinishMissionBoardRes;
-import com.moing.backend.domain.mission.application.dto.res.GatherSingleMissionRes;
 import com.moing.backend.domain.mission.application.dto.res.RepeatMissionBoardRes;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionStatus;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchiveStatus;
 import org.springframework.stereotype.Repository;
@@ -23,6 +23,8 @@ public interface MissionArchiveCustomRepository {
     Optional<List<RepeatMissionBoardRes>> findRepeatMissionArchivesByMemberId(Long memberId, Long teamId, MissionStatus status);
 
     Optional<List<FinishMissionBoardRes>> findFinishMissionsByStatus(Long memberId, Long teamId);
+
+    Optional<List<MissionArchivePhotoRes>> findTop5ArchivesByTeam(List<Long> teamIds);
 
 
     }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
@@ -1,23 +1,19 @@
 package com.moing.backend.domain.missionArchive.domain.repository;
 
 import com.moing.backend.domain.mission.application.dto.res.FinishMissionBoardRes;
-import com.moing.backend.domain.mission.application.dto.res.GatherSingleMissionRes;
 import com.moing.backend.domain.mission.application.dto.res.RepeatMissionBoardRes;
-import com.moing.backend.domain.mission.application.dto.res.SingleMissionBoardRes;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionStatus;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
-import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchiveStatus;
-import com.moing.backend.domain.team.domain.entity.Team;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import feign.Param;
-import org.springframework.data.jpa.repository.Query;
 
 import javax.persistence.EntityManager;
 import java.util.ArrayList;
@@ -26,7 +22,6 @@ import java.util.Optional;
 
 import static com.moing.backend.domain.mission.domain.entity.QMission.mission;
 import static com.moing.backend.domain.missionArchive.domain.entity.QMissionArchive.*;
-import static com.moing.backend.domain.missionHeart.domain.entity.QMissionHeart.missionHeart;
 import static javax.swing.Spring.constant;
 
 public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomRepository {
@@ -178,6 +173,40 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
                 )
                 .fetch()
         );
+    }
+
+
+    public Optional<List<MissionArchivePhotoRes>> findTop5ArchivesByTeam(List<Long> teamIds) {
+        List<Tuple> queryResults = queryFactory
+                .select(missionArchive.mission.team.teamId, missionArchive.archive)
+                .from(missionArchive)
+                .where(missionArchive.mission.team.teamId.in(teamIds))
+                .orderBy(missionArchive.createdDate.desc())
+                .limit(14)
+                .fetch();
+
+        List<MissionArchivePhotoRes> resultDTOs = new ArrayList<>();
+
+        for (Tuple tuple : queryResults) {
+            Long teamId = tuple.get(missionArchive.mission.team.teamId);
+            String photo = tuple.get(missionArchive.archive);
+
+            // Check if a TeamPhotoDTO with the same teamId already exists in the list
+            MissionArchivePhotoRes existingDTO = resultDTOs.stream()
+                    .filter(dto -> dto.getTeamId().equals(teamId))
+                    .findFirst()
+                    .orElse(null);
+
+            if (existingDTO != null) {
+                existingDTO.getPhoto().add(photo);
+            } else {
+                List<String> photoList = new ArrayList<>();
+                photoList.add(photo);
+                resultDTOs.add(new MissionArchivePhotoRes(teamId, photoList));
+            }
+        }
+
+        return Optional.ofNullable(resultDTOs);
     }
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
@@ -5,6 +5,7 @@ import com.moing.backend.domain.mission.application.dto.res.GatherSingleMissionR
 import com.moing.backend.domain.mission.application.dto.res.RepeatMissionBoardRes;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionStatus;
 import com.moing.backend.domain.mission.domain.repository.MissionRepository;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
 import com.moing.backend.domain.missionArchive.domain.repository.MissionArchiveRepository;
 import com.moing.backend.domain.missionArchive.exception.NotFoundMissionArchiveException;
@@ -99,6 +100,9 @@ public class MissionArchiveQueryService {
         return missionArchiveRepository.findFinishMissionsByStatus(memberId, teamId).orElseThrow(NotFoundMissionArchiveException::new);
     }
 
+    public List<MissionArchivePhotoRes> findTop5ArchivesByTeam(List<Long> teamIds) {
+        return missionArchiveRepository.findTop5ArchivesByTeam(teamIds).orElse(null);
+    }
 
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
@@ -1,5 +1,6 @@
 package com.moing.backend.domain.missionArchive.presentation;
 
+import com.moing.backend.domain.mission.application.dto.res.GatherRepeatMissionRes;
 import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveStatusRes;
@@ -127,6 +128,8 @@ public class MissionArchiveController {
                                                                                          @PathVariable("missionId") Long missionId) {
         return ResponseEntity.ok(SuccessResponse.create(MISSION_ARCHIVE_PEOPLE_STATUS_SUCCESS.getMessage(), this.repeatMissionArchiveReadUseCase.getMyMissionDoneStatus(user.getSocialId(),missionId)));
     }
+
+
 
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionGatherController.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionGatherController.java
@@ -5,6 +5,8 @@ import com.moing.backend.domain.mission.application.dto.res.GatherSingleMissionR
 import com.moing.backend.domain.mission.application.dto.res.RepeatMissionBoardRes;
 import com.moing.backend.domain.mission.application.service.MissionArchiveBoardUseCase;
 import com.moing.backend.domain.mission.application.service.MissionGatherBoardUseCase;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
+import com.moing.backend.domain.missionArchive.application.service.MissionArchiveReadUseCase;
 import com.moing.backend.global.config.security.dto.User;
 import com.moing.backend.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
@@ -48,6 +50,16 @@ public class MissionGatherController {
     public ResponseEntity<SuccessResponse<List<GatherRepeatMissionRes>>> getMyActiveRepeatMission(@AuthenticationPrincipal User user) {
         return ResponseEntity.ok(SuccessResponse.create(ACTIVE_REPEAT_MISSION_SUCCESS.getMessage(), this.missionGatherBoardUseCase.getAllActiveRepeatMissions( user.getSocialId())));
     }
+
+
+    @GetMapping("/my-teams")
+    public ResponseEntity<SuccessResponse<List<MissionArchivePhotoRes>>> getArchivesByTeam(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(SuccessResponse.create(MISSION_ARCHIVE_BY_TEAM.getMessage(), this.missionGatherBoardUseCase.getArchivePhotoByTeamRes(user.getSocialId())));
+    }
+
+
+
+
 
 
 }

--- a/src/main/java/com/moing/backend/domain/missionHeart/application/dto/MissionHeartRes.java
+++ b/src/main/java/com/moing/backend/domain/missionHeart/application/dto/MissionHeartRes.java
@@ -1,10 +1,14 @@
 package com.moing.backend.domain.missionHeart.application.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Getter
+@AllArgsConstructor
 @Builder
+@NoArgsConstructor
+@Getter
 public class MissionHeartRes {
     private Long missionArchiveId;
     private String missionHeartStatus;

--- a/src/test/java/com/moing/backend/domain/mission/representation/MissionControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/mission/representation/MissionControllerTest.java
@@ -64,8 +64,8 @@ public class MissionControllerTest extends CommonControllerTest {
                 .rule("rule")
                 .content("content")
                 .number(1)
-                .type("ONCE")
-                .way("TEXT")
+                .type("ONCE/REPEAT")
+                .way("TEXT/PHOTO/LINK")
                 .build();
 
         String body = objectMapper.writeValueAsString(input);
@@ -73,13 +73,13 @@ public class MissionControllerTest extends CommonControllerTest {
         MissionCreateRes output = MissionCreateRes.builder()
                 .missionId(1L)
                 .title("title")
-                .dueTo("dueTo")
+                .dueTo("2023-12-31 23:39:22.333")
                 .rule("rule")
                 .content("content")
                 .number(1)
-                .type("TEXT")
-                .status("WAIT")
-                .way("TEXT")
+                .type("ONCE/REPEAT")
+                .status("END/ONGOING/SUCCESS/FAIL")
+                .way("TEXT/PHOTO/LINK")
                 .build();
 
         given(missionCreateUseCase.createMission(any(),any(),any())).willReturn(output);
@@ -110,7 +110,7 @@ public class MissionControllerTest extends CommonControllerTest {
                                         fieldWithPath("rule").description("미션 규칙"),
                                         fieldWithPath("content").description("미션 내용"),
                                         fieldWithPath("number").description("미션 반복 횟수"),
-                                        fieldWithPath("type").description("미션 타입"),
+                                        fieldWithPath("type").description("미션 유형(단일/반복)"),
                                         fieldWithPath("way").description("미션 진행 방법")
                                 ),
                                 responseFields(
@@ -122,8 +122,8 @@ public class MissionControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.rule").description("미션 규칙"),
                                         fieldWithPath("data.content").description("미션 내용"),
                                         fieldWithPath("data.number").description("미션 반복 횟수"),
-                                        fieldWithPath("data.type").description("미션 타입"),
-                                        fieldWithPath("data.way").description("미션 진행 방법"),
+                                        fieldWithPath("data.type").description("미션 유형(단일/반복)"),
+                                        fieldWithPath("data.way").description("미션 진행 방법(사진/글/링크)"),
                                         fieldWithPath("data.status").description("미션 진행 상태")
                                 )
                         )
@@ -137,7 +137,7 @@ public class MissionControllerTest extends CommonControllerTest {
         //given
         MissionReq input = MissionReq.builder()
                 .title("title")
-                .dueTo("dueTo")
+                .dueTo("2023-12-31 23:39:22.333")
                 .rule("rule")
                 .content("content")
                 .number(1)
@@ -150,12 +150,12 @@ public class MissionControllerTest extends CommonControllerTest {
         MissionCreateRes output = MissionCreateRes.builder()
                 .missionId(1L)
                 .title("title")
-                .dueTo("dueTo")
+                .dueTo("2023-12-31 23:39:22.333")
                 .rule("rule")
                 .content("content")
                 .number(1)
-                .type("TEXT")
-                .status("WAIT")
+                .type("ONCE")
+                .status("END")
                 .way("TEXT")
                 .build();
 
@@ -201,9 +201,9 @@ public class MissionControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.rule").description("미션 규칙"),
                                         fieldWithPath("data.content").description("미션 내용"),
                                         fieldWithPath("data.number").description("미션 반복 횟수"),
-                                        fieldWithPath("data.type").description("미션 타입"),
-                                        fieldWithPath("data.way").description("미션 진행 방법"),
-                                        fieldWithPath("data.status").description("미션 진행 상태")
+                                        fieldWithPath("data.type").description("미션 유형(ONCE/REPEAT)"),
+                                        fieldWithPath("data.way").description("미션 진행 방법(TEXT/PHOTO/LINK)"),
+                                        fieldWithPath("data.status").description("미션 진행 상태(END/ONGOING/SUCCESS/FAIL)")
 
                                 )
                         )
@@ -219,10 +219,10 @@ public class MissionControllerTest extends CommonControllerTest {
 
         MissionReadRes output = MissionReadRes.builder()
                 .title("title")
-                .dueTo("dueTo")
+                .dueTo("2023-12-31 23:39:22.333")
                 .rule("rule")
                 .content("content")
-                .type("TEXT")
+                .type("ONCE")
                 .way("TEXT")
                 .build();
 
@@ -257,8 +257,8 @@ public class MissionControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.dueTo").description("미션 마감 날짜"),
                                         fieldWithPath("data.rule").description("미션 규칙"),
                                         fieldWithPath("data.content").description("미션 내용"),
-                                        fieldWithPath("data.type").description("미션 타입"),
-                                        fieldWithPath("data.way").description("미션 진행 방법")
+                                        fieldWithPath("data.way").description("미션 진행 방법(TEXT/PHOTO/LINK)"),
+                                        fieldWithPath("data.type").description("미션 유형(ONCE/REPEAT)")
 
                                 )
                         )
@@ -308,7 +308,7 @@ public class MissionControllerTest extends CommonControllerTest {
         //given
 
 
-        String output = "" ;
+        String output = "SPORTS/HABIT/TEST/STUDY/READING/ETC" ;
 
         given(missionReadUseCase.getTeamCategory(any())).willReturn(output);
 

--- a/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionGatherControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionGatherControllerTest.java
@@ -3,6 +3,8 @@ package com.moing.backend.domain.missionArchive.representation;
 import com.moing.backend.config.CommonControllerTest;
 import com.moing.backend.domain.mission.application.dto.res.*;
 import com.moing.backend.domain.mission.application.service.MissionGatherBoardUseCase;
+import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
+import com.moing.backend.domain.missionArchive.application.service.MissionArchiveReadUseCase;
 import com.moing.backend.domain.missionArchive.presentation.MissionGatherController;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,7 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.moing.backend.domain.missionArchive.domain.constant.MissionArchiveResponseMessage.*;
@@ -20,8 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
@@ -118,6 +120,49 @@ public class MissionGatherControllerTest extends CommonControllerTest {
                                         fieldWithPath("data[].totalNum").description("전체 횟수")
 
 
+                                )
+                        )
+                )
+                .andReturn();
+
+    }
+    @Test
+    public void 미션_모아보기_팀별() throws Exception {
+        //given
+
+        List<String> objects = new ArrayList<>();
+        objects.add("1");
+        objects.add("2");
+
+        List<MissionArchivePhotoRes> output = Lists.newArrayList(MissionArchivePhotoRes.builder()
+                        .teamId(1L)
+                .photo(objects)
+                .build());
+
+        given(missionGatherBoardUseCase.getArchivePhotoByTeamRes(any())).willReturn(output);
+
+        //when
+        ResultActions actions = mockMvc.perform(RestDocumentationRequestBuilders.
+                get("/api/team/my-teams")
+                .header("Authorization", "Bearer ACCESS_TOKEN")
+                .contentType(MediaType.APPLICATION_JSON)
+
+        );
+
+        //then
+        actions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName("Authorization").description("접근 토큰")
+                                ),
+
+                                responseFields(
+                                        fieldWithPath("isSuccess").description("true"),
+                                        fieldWithPath("message").description(MISSION_ARCHIVE_BY_TEAM.getMessage()),
+                                        fieldWithPath("data[].teamId").description("팀 아이디"),
+                                        fieldWithPath("data[].photo[]").description("팀별 미션 인증물 사진들")
                                 )
                         )
                 )


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- mission 관련 dto 객체 lombok 추가
   - @Builder,@Getter,@NoArgsConstructor, @AllArgsConstructor 가 없어 오류나는 상황 해결 
- mission API 문서 수정
- 소모임별 초기 화면에 들어갈 팀별 미션 인증물 리턴
## 변경 사항
- mission 관련 dto 객체 lombok 추가
  - 다른건 괜찮은데 왜 mission 관련해서만 에러가 났을까 .. 
- mission API 문서에 enum 값 설명 추가 
- 소모임별 초기 화면에 들어갈 팀별 미션 인증물 리턴

