### PR TITLE
fix : 미션모아보기-팀별 adoc 반영

### DIFF
--- a/src/docs/asciidoc/MissionGatherBoard-API.adoc
+++ b/src/docs/asciidoc/MissionGatherBoard-API.adoc
@@ -13,3 +13,9 @@ operation::mission-gather-controller-test/미션_모아보기_단일_미션[snip
 operation::mission-gather-controller-test/미션_모아보기_반복_미션[snippets='http-request,http-response,response-fields']
 
 ---
+
+[[MissionBoard-미션-모아보기-팀별]]
+== 미션_모아보기_팀별
+operation::mission-gather-controller-test/미션_모아보기_팀별[snippets='http-request,http-response,response-fields']
+
+---


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
지난번에 pr 날렸던 팀별 미션 모아보기 ( 소모임 메인 사진 리스트 ) 가 api 문서에 반영이 안되어있어 다시 pr 날립니다!
