### PR TITLE
feat : 나의 미션 인증 조회 시 당일인증 여부 추가 및 당일 중복 미션 인증 불가

### DIFF
--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MyMissionArchiveRes.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MyMissionArchiveRes.java
@@ -1,0 +1,31 @@
+package com.moing.backend.domain.missionArchive.application.dto.res;
+
+import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+@Getter
+public class MyMissionArchiveRes {
+    private String today;
+    private List<MissionArchiveRes> archives;
+
+    public void updateArchives(List<MissionArchiveRes> archives) {
+        this.archives = archives;
+    }
+
+    public void updateTodayStatus(Boolean bo) {
+        if (bo) {
+            this.today = "True";
+        } else {
+            this.today = "False";
+        }
+    }
+
+}

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveCreateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveCreateUseCase.java
@@ -58,7 +58,12 @@ public class MissionArchiveCreateUseCase {
         }
         // 반복 미션일 경우
         if (mission.getType() == MissionType.REPEAT) {
-            newArchive.updateCount(missionArchiveQueryService.findMyDoneArchives(memberId, missionId)+1);
+            // 당일 1회 인증만 가능
+            if(!missionArchiveQueryService.findDoneTodayArchive(memberId,missionId))
+                newArchive.updateCount(missionArchiveQueryService.findMyDoneArchives(memberId, missionId)+1);
+            else
+                throw new NoMoreMissionArchiveException();
+
         }else {
             newArchive.updateCount(missionArchiveQueryService.findMyDoneArchives(memberId, missionId)+1);
         }

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveReadUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveReadUseCase.java
@@ -4,10 +4,7 @@ import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.member.domain.service.MemberGetService;
 import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.mission.domain.service.MissionQueryService;
-import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchivePhotoRes;
-import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
-import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveStatusRes;
-import com.moing.backend.domain.missionArchive.application.dto.res.PersonalArchiveRes;
+import com.moing.backend.domain.missionArchive.application.dto.res.*;
 import com.moing.backend.domain.missionArchive.application.mapper.MissionArchiveMapper;
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
 import com.moing.backend.domain.team.domain.entity.Team;
@@ -33,11 +30,19 @@ public class MissionArchiveReadUseCase {
 
 
     // 미션 인증 조회
-    public List<MissionArchiveRes> getMyArchive(String userSocialId, Long missionId) {
+    public MyMissionArchiveRes getMyArchive(String userSocialId, Long missionId) {
 
         Long memberId = memberGetService.getMemberBySocialId(userSocialId).getMemberId();
 
-        return MissionArchiveMapper.mapToMissionArchiveResList(missionArchiveQueryService.findMyArchive(memberId, missionId), memberId);
+        MyMissionArchiveRes myMissionArchiveRes = new MyMissionArchiveRes();
+
+        List<MissionArchiveRes> missionArchiveRes = MissionArchiveMapper.mapToMissionArchiveResList(missionArchiveQueryService.findMyArchive(memberId, missionId), memberId);
+        myMissionArchiveRes.updateArchives(missionArchiveRes);
+
+        myMissionArchiveRes.updateTodayStatus(missionArchiveQueryService.findDoneTodayArchive(memberId, missionId));
+
+        return myMissionArchiveRes;
+
     }
 
     // 모두의 미션 인증 목록 조회

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveUpdateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveUpdateUseCase.java
@@ -8,6 +8,7 @@ import com.moing.backend.domain.mission.domain.entity.constant.MissionStatus;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionWay;
 import com.moing.backend.domain.mission.domain.service.MissionQueryService;
+import com.moing.backend.domain.mission.exception.NoAccessCreateMission;
 import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.mapper.MissionArchiveMapper;
@@ -22,11 +23,13 @@ import com.moing.backend.domain.missionState.domain.service.MissionStateQuerySer
 import com.moing.backend.domain.missionState.domain.service.MissionStateSaveService;
 import com.moing.backend.domain.missionHeart.domain.entity.MissionHeart;
 import com.moing.backend.domain.missionHeart.domain.service.MissionHeartQueryService;
+import com.moing.backend.domain.missionState.exception.NoAccessMissionArchiveException;
 import com.moing.backend.domain.team.domain.entity.Team;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -71,6 +74,10 @@ public class MissionArchiveUpdateUseCase {
             mission.updateStatus(MissionStatus.SUCCESS);
             // 점수 반영 로직
 
+        }
+        // 반복미션의 경우 당일이 지나면 업데이트 불가능
+        if (!(updateArchive.getLastModifiedDate().getDayOfWeek().equals(LocalDateTime.now().getDayOfWeek()))) {
+            throw new NoAccessMissionArchiveException();
         }
 
         updateArchive.updateArchive(missionReq);

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepository.java
@@ -28,5 +28,6 @@ public interface MissionArchiveCustomRepository {
 
     Optional<List<MissionArchivePhotoRes>> findTop5ArchivesByTeam(List<Long> teamIds);
 
+    Boolean findMyArchivesToday(Long memberId,Long missionId);
 
     }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
@@ -17,9 +17,11 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import feign.Param;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.Query;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +30,7 @@ import static com.moing.backend.domain.mission.domain.entity.QMission.mission;
 import static com.moing.backend.domain.missionArchive.domain.entity.QMissionArchive.*;
 import static com.moing.backend.domain.missionState.domain.entity.QMissionState.missionState;
 import static javax.swing.Spring.constant;
-
+@Slf4j
 public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomRepository {
 
     private final JPAQueryFactory queryFactory;
@@ -172,7 +174,7 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
                 .select(Projections.constructor(RepeatMissionBoardRes.class,
                                 mission.id,
                                 mission.title,
-                                missionArchive.count.coalesce(0L).as("done"),
+                                missionArchive.count.max().coalesce(0L).as("done"),
                                 mission.number,
                                 mission.way.stringValue()
                         ))
@@ -184,10 +186,8 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
                         mission.type.eq(MissionType.REPEAT),
                         mission.status.eq(MissionStatus.ONGOING)
                 )
-
-//                .groupBy(missionArchive.mission)
+                .groupBy(mission)
                 .fetch());
-
 
     }
 
@@ -252,6 +252,29 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
 
         return Optional.ofNullable(resultDTOs);
     }
+
+
+    public Boolean findMyArchivesToday(Long memberId, Long missionId) {
+        LocalDateTime today = LocalDateTime.now();
+        LocalDateTime startOfToday = today.withHour(0).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime endOfToday = today.withHour(23).withMinute(59).withSecond(59).withNano(999999999);
+
+        log.info("today"+ today);
+        log.info("startToday"+startOfToday);
+        log.info("endToday"+endOfToday);
+
+        long count = queryFactory
+                .selectFrom(missionArchive)
+                .where(
+                        missionArchive.member.memberId.eq(memberId),
+                        missionArchive.mission.id.eq(missionId),
+                        missionArchive.lastModifiedDate.between(startOfToday, endOfToday) // createdDate와 오늘의 시작과 끝을 비교
+                )
+                .fetchCount();
+
+        return count > 0;
+    }
+
 
 
 }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
@@ -66,6 +66,16 @@ public class MissionArchiveQueryService {
         }
     }
 
+    public Boolean isTodayDone(Long memberId, Long missionId) {
+        Optional<List<MissionArchive>> byMemberId = missionArchiveRepository.findArchivesByMissionIdAndMemberId(memberId, missionId);
+        if (byMemberId.isPresent()) {
+
+            return Boolean.TRUE;
+        } else {
+            return Boolean.FALSE;
+        }
+    }
+
     // team의 mission id 들 가져와서 나의 mission archive 리턴
 
     /**
@@ -104,6 +114,10 @@ public class MissionArchiveQueryService {
 
     public List<MissionArchivePhotoRes> findTop5ArchivesByTeam(List<Long> teamIds) {
         return missionArchiveRepository.findTop5ArchivesByTeam(teamIds).orElse(null);
+    }
+
+    public boolean findDoneTodayArchive(Long memberId, Long missionId) {
+        return missionArchiveRepository.findMyArchivesToday(memberId, missionId);
     }
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/presentation/MissionArchiveController.java
@@ -4,6 +4,7 @@ import com.moing.backend.domain.mission.application.dto.res.GatherRepeatMissionR
 import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveStatusRes;
+import com.moing.backend.domain.missionArchive.application.dto.res.MyMissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.PersonalArchiveRes;
 import com.moing.backend.domain.missionArchive.application.service.*;
 import com.moing.backend.domain.missionHeart.application.dto.MissionHeartRes;
@@ -67,9 +68,9 @@ public class MissionArchiveController {
      **/
 
     @GetMapping()
-    public ResponseEntity<SuccessResponse<List<MissionArchiveRes>>> getMyArchive(@AuthenticationPrincipal User user,
-                                                                            @PathVariable("teamId") Long teamId,
-                                                                            @PathVariable("missionId") Long missionId) {
+    public ResponseEntity<SuccessResponse<MyMissionArchiveRes>> getMyArchive(@AuthenticationPrincipal User user,
+                                                                             @PathVariable("teamId") Long teamId,
+                                                                             @PathVariable("missionId") Long missionId) {
         return ResponseEntity.ok(SuccessResponse.create(READ_MY_ARCHIVE_SUCCESS.getMessage(), this.missionArchiveReadUseCase.getMyArchive(user.getSocialId(), missionId)));
     }
 

--- a/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionArchiveControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionArchiveControllerTest.java
@@ -5,6 +5,7 @@ import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiv
 import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveStatusRes;
+import com.moing.backend.domain.missionArchive.application.dto.res.MyMissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.dto.res.PersonalArchiveRes;
 import com.moing.backend.domain.missionArchive.application.service.*;
 import com.moing.backend.domain.missionArchive.presentation.MissionArchiveController;
@@ -185,7 +186,9 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
     public void 나의_미션_인증_조회() throws Exception {
         //given
 
-        List<MissionArchiveRes> output = Lists.newArrayList(MissionArchiveRes.builder()
+
+
+        List<MissionArchiveRes> archives = Lists.newArrayList(MissionArchiveRes.builder()
                 .archiveId(1L)
                 .archive("content[s3 Link / text / link]")
                 .way("TEXT/LINK/PHOTO")
@@ -195,6 +198,11 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                 .heartStatus("[True/False]")
                 .hearts(1L)
                 .build());
+
+        MyMissionArchiveRes output = MyMissionArchiveRes.builder()
+                .archives(archives)
+                .today("True/False")
+                .build();
 
         given(missionArchiveReadUseCase.getMyArchive(any(),any())).willReturn(output);
 
@@ -223,14 +231,15 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                                 responseFields(
                                         fieldWithPath("isSuccess").description("true"),
                                         fieldWithPath("message").description(READ_MY_ARCHIVE_SUCCESS.getMessage()),
-                                        fieldWithPath("data[].archiveId").description("미션 인증 아이디"),
-                                        fieldWithPath("data[].archive").description("미션 인증물 [s3URL/text/링크]"),
-                                        fieldWithPath("data[].way").description("미션 인증물 방식"),
-                                        fieldWithPath("data[].createdDate").description("미션 제출 시각"),
-                                        fieldWithPath("data[].status").description("미션 인증 상태"),
-                                        fieldWithPath("data[].count").description("미션 인증 횟수"),
-                                        fieldWithPath("data[].heartStatus").description("미션 인증 좋아요 상태"),
-                                        fieldWithPath("data[].hearts").description("미션 인증 좋아요 수")
+                                        fieldWithPath("data.today").description("오늘 인증 여부"),
+                                        fieldWithPath("data.archives[].archiveId").description("미션 인증 아이디"),
+                                        fieldWithPath("data.archives[].archive").description("미션 인증물 [s3URL/text/링크]"),
+                                        fieldWithPath("data.archives[].way").description("미션 인증물 방식"),
+                                        fieldWithPath("data.archives[].createdDate").description("미션 제출 시각"),
+                                        fieldWithPath("data.archives[].status").description("미션 인증 상태"),
+                                        fieldWithPath("data.archives[].count").description("미션 인증 횟수"),
+                                        fieldWithPath("data.archives[].heartStatus").description("미션 인증 좋아요 상태"),
+                                        fieldWithPath("data.archives[].hearts").description("미션 인증 좋아요 수")
 
 
                                         )


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 나의 미션 인증 조회 시 당일인증 여부 추가 및 당일 중복 미션 인증 불가
## 변경 사항

## 코드 리뷰 시 참고 사항

## 테스트 결과
