### PR TITLE
목표보드 조회 시 현재 유저 아이디 추가

### DIFF
--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/TeamInfo.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/TeamInfo.java
@@ -19,5 +19,6 @@ public class TeamInfo {
     private Integer numOfMember; //소모임원 수
     private Category category; //카테고리
     private String introduction; //소개
+    private Long currentUserId; //현재 유저 아이디
     private List<TeamMemberInfo> teamMemberInfoList = new ArrayList<>(); //소모임원 정보
 }

--- a/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
+++ b/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
@@ -30,8 +30,8 @@ public class TeamMapper {
                 .build();
     }
 
-    public GetTeamDetailResponse toTeamDetailResponse(Team team, Integer boardNum, List<TeamMemberInfo> teamMemberInfoList) {
-        TeamInfo teamInfo = new TeamInfo(team.isDeleted(), team.getDeletionTime(), team.getName(), teamMemberInfoList.size(), team.getCategory(), team.getIntroduction(), teamMemberInfoList);
+    public GetTeamDetailResponse toTeamDetailResponse(Long memberId, Team team, Integer boardNum, List<TeamMemberInfo> teamMemberInfoList) {
+        TeamInfo teamInfo = new TeamInfo(team.isDeleted(), team.getDeletionTime(), team.getName(), teamMemberInfoList.size(), team.getCategory(), team.getIntroduction(), memberId, teamMemberInfoList);
         return GetTeamDetailResponse.builder()
                 .boardNum(boardNum)
                 .teamInfo(teamInfo)

--- a/src/main/java/com/moing/backend/domain/team/application/service/GetTeamUserCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/GetTeamUserCase.java
@@ -37,7 +37,7 @@ public class GetTeamUserCase {
         Integer boardNum = boardGetService.getUnReadBoardNum(teamId, member.getMemberId());
         List<TeamMemberInfo> teamMemberInfoList = teamMemberGetService.getTeamMemberInfo(teamId);
         Team team = teamGetService.getTeamByTeamId(teamId);
-        return teamMapper.toTeamDetailResponse(team, boardNum, teamMemberInfoList);
+        return teamMapper.toTeamDetailResponse(member.getMemberId(), team, boardNum, teamMemberInfoList);
     }
 
     public GetCurrentStatusResponse getCurrentStatus(Long teamId) {

--- a/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
@@ -194,6 +194,7 @@ public class TeamControllerTest extends CommonControllerTest {
                 .numOfMember(1)
                 .category(Category.ETC)
                 .introduction("소모임 소개글")
+                .currentUserId(1L)
                 .teamMemberInfoList(teamMemberInfoList).build();
 
         GetTeamDetailResponse output = GetTeamDetailResponse
@@ -235,6 +236,7 @@ public class TeamControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.teamInfo.introduction").description("모임 소개"),
                                         fieldWithPath("data.teamInfo.isDeleted").description("삭제여부"),
                                         fieldWithPath("data.teamInfo.deletionTime").description("삭제 시간 (삭제 안했으면 null)"),
+                                        fieldWithPath("data.teamInfo.currentUserId").description("현재 유저 아이디"),
                                         fieldWithPath("data.teamInfo.teamMemberInfoList[0].memberId").description("유저 아이디"),
                                         fieldWithPath("data.teamInfo.teamMemberInfoList[0].nickName").description("유저 닉네임"),
                                         fieldWithPath("data.teamInfo.teamMemberInfoList[0].profileImage").description("유저 프로필 이미지"),


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- 목표보드 조회 시 유저 아이디도 같이 넘겨줄 수 있게 수정

## 변경 사항
TeamInfo에서 
private Long currentUserId; //현재 유저 아이디
추가