### PR TITLE
refactor: 닉네임 중복 검사 API endPoint 수정

### DIFF
--- a/src/docs/asciidoc/Auth-API.adoc
+++ b/src/docs/asciidoc/Auth-API.adoc
@@ -40,7 +40,7 @@ operation::auth-controller-test/reissue_token[snippets='http-request,http-respon
 
 [[Auth-닉네임-검사]]
 == Auth 닉네임 중복검사 요청
-operation::auth-controller-test/check_nickname_중복o[snippets='http-request,path-parameters']
+operation::auth-controller-test/check_nickname_중복o[snippets='http-request']
 
 == Auth 닉네임 중복인 경우
 operation::auth-controller-test/check_nickname_중복o[snippets='http-response,response-fields']

--- a/src/main/java/com/moing/backend/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/moing/backend/domain/auth/presentation/AuthController.java
@@ -74,11 +74,11 @@ public class AuthController {
 
     /**
      * 닉네임 중복검사
-     * [GET] api/auth/nickname
+     * [GET] api/auth/checkNickName?nickname={}
      * 작성자 : 김민수
      */
-    @GetMapping("/nickname/{nickname}")
-    public ResponseEntity<SuccessResponse<CheckNicknameResponse>> checkNickname(@PathVariable String nickname){
+    @GetMapping("/checkNickname")
+    public ResponseEntity<SuccessResponse<CheckNicknameResponse>> checkNickname(@RequestParam String nickname){
         return ResponseEntity.ok(SuccessResponse.create(CHECK_NICKNAME_SUCCESS.getMessage(), checkNicknameService.checkNickname(nickname)));
     }
 

--- a/src/test/java/com/moing/backend/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/auth/presentation/AuthControllerTest.java
@@ -21,12 +21,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @WebMvcTest(AuthController.class)
@@ -410,15 +410,14 @@ class AuthControllerTest extends CommonControllerTest {
 
         // when
         ResultActions actions = mockMvc.perform(
-                get("/api/auth/nickname/{nickname}", "NICKNAME")
-                .contentType(MediaType.APPLICATION_JSON)
+                get("/api/auth/checkNickname?nickname=minsu")
         );
 
         // then
         actions
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
-                        pathParameters(
+                        requestParameters(
                                 parameterWithName("nickname").description("중복검사할 닉네임")
                         ),
                         responseFields(
@@ -437,15 +436,15 @@ class AuthControllerTest extends CommonControllerTest {
 
 
         // when
-        ResultActions actions =mockMvc.perform(
-                get("/api/auth/nickname/{nickname}", "NICKNAME"));
-
+        ResultActions actions = mockMvc.perform(
+                get("/api/auth/checkNickname?nickname=minsu")
+        );
 
         // then
         actions
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
-                        pathParameters(
+                        requestParameters(
                                 parameterWithName("nickname").description("중복검사할 닉네임")
                         ),
                         responseFields(


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- 닉네임 중복 검사 API endPoint 수정

## 변경 사항
/api/auth/nickname/NICKNAME → /api/auth/checkNickname?nickname={nickname} 
