### PR TITLE
member삭제 오류 해결

### DIFF
--- a/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
@@ -17,6 +17,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id")
     private Long memberId;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String socialId;
 
     @Enumerated(EnumType.STRING)
@@ -44,7 +45,7 @@ public class Member extends BaseTimeEntity {
     private RegistrationStatus registrationStatus;
 
     @Convert(converter = AesConverter.class)
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     private String profileImage;
@@ -56,7 +57,6 @@ public class Member extends BaseTimeEntity {
     private LocalDate birthDate;
 
     @Convert(converter = AesConverter.class)
-    @Column(unique=true)
     private String nickName;
 
     @Column(nullable = false)
@@ -78,6 +78,10 @@ public class Member extends BaseTimeEntity {
     @ColumnDefault("true")
     @Column(nullable = false)
     private boolean isFirePush;
+
+    private boolean isDeleted;
+
+    private LocalDateTime lastSignInTime;
 
     @OneToMany(mappedBy = "member")
     private List<TeamMember> teamMembers = new ArrayList<>(); //최대 3개이므로 양방향
@@ -140,6 +144,10 @@ public class Member extends BaseTimeEntity {
         this.fcmToken = fcmToken;
     }
 
+    public void updateLastSignInTime(LocalDateTime time){
+        this.lastSignInTime=time;
+    }
+
     public Member(LocalDate birthDate, String email, String fcmToken, Gender gender, String introduction, String nickName, String profileImage, SocialProvider provider, RegistrationStatus registrationStatus, Role role, String socialId) {
         this.birthDate = birthDate;
         this.email = email;
@@ -152,6 +160,10 @@ public class Member extends BaseTimeEntity {
         this.registrationStatus = registrationStatus;
         this.role = role;
         this.socialId = socialId;
+    }
+
+    public void deleteMember(){
+        this.isDeleted=true;
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepository.java
@@ -6,4 +6,8 @@ import java.util.Optional;
 
 public interface MemberCustomRepository {
     boolean checkNickname(String nickname);
+
+    Optional<Member> findNotDeletedBySocialId(String socialId);
+
+    Optional<Member> findNotDeletedByEmail(String email);
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepository.java
@@ -10,4 +10,5 @@ public interface MemberCustomRepository {
     Optional<Member> findNotDeletedBySocialId(String socialId);
 
     Optional<Member> findNotDeletedByEmail(String email);
+    Optional<Member> findNotDeletedByMemberId(Long id);
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepositoryImpl.java
@@ -43,4 +43,13 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .where(member.isDeleted.eq(false))
                 .fetchOne());
     }
+
+    @Override
+    public Optional<Member> findNotDeletedByMemberId(Long id) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(member)
+                .where(member.memberId.eq(id))
+                .where(member.isDeleted.eq(false))
+                .fetchOne());
+    }
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepositoryImpl.java
@@ -22,6 +22,25 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .selectOne()
                 .from(member)
                 .where(member.nickName.eq(nickname))
+                .where(member.isDeleted.eq(false))
                 .fetchFirst() != null;
+    }
+
+    @Override
+    public Optional<Member> findNotDeletedBySocialId(String socialId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(member)
+                .where(member.socialId.eq(socialId))
+                .where(member.isDeleted.eq(false))
+                .fetchOne());
+    }
+
+    @Override
+    public Optional<Member> findNotDeletedByEmail(String email) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(member)
+                .where(member.email.eq(email))
+                .where(member.isDeleted.eq(false))
+                .fetchOne());
     }
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/repository/MemberRepository.java
@@ -7,8 +7,4 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 
-    Optional<Member> findBySocialId(String socialId);
-
-    Optional<Member> findByEmail(String email);
-
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/service/MemberGetService.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/service/MemberGetService.java
@@ -19,6 +19,6 @@ public class MemberGetService {
     }
 
     public Member getMemberByMemberId(Long memberId) {
-        return memberRepository.findByMemberId(memberId).orElseThrow(()->new NotFoundBySocialIdException());
+        return memberRepository.findNotDeletedByMemberId(memberId).orElseThrow(()->new NotFoundBySocialIdException());
     }
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/service/MemberGetService.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/service/MemberGetService.java
@@ -15,6 +15,6 @@ public class MemberGetService {
     private final MemberRepository memberRepository;
 
     public Member getMemberBySocialId(String socialId){
-        return memberRepository.findBySocialId(socialId).orElseThrow(()->new NotFoundBySocialIdException());
+        return memberRepository.findNotDeletedBySocialId(socialId).orElseThrow(()->new NotFoundBySocialIdException());
     }
 }

--- a/src/main/java/com/moing/backend/domain/member/domain/service/MemberSaveService.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/service/MemberSaveService.java
@@ -6,6 +6,7 @@ import com.moing.backend.global.annotation.DomainService;
 import lombok.AllArgsConstructor;
 
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @DomainService
@@ -16,11 +17,12 @@ public class MemberSaveService {
     private final MemberRepository memberRepository;
 
     public Member saveMember(Member member) {
-        Optional<Member>findMember=memberRepository.findByEmail(member.getEmail());
+        Optional<Member>findMember=memberRepository.findNotDeletedByEmail(member.getEmail());
         if(findMember.isEmpty()){
             return memberRepository.save(member);
         } else {
             findMember.get().updateFcmToken(member.getFcmToken());
+            findMember.get().updateLastSignInTime(LocalDateTime.now());
             return findMember.get();
         }
     }

--- a/src/main/java/com/moing/backend/domain/mypage/application/service/WithdrawUserCase.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/service/WithdrawUserCase.java
@@ -9,6 +9,7 @@ import com.moing.backend.domain.mypage.application.dto.request.WithdrawRequest;
 import com.moing.backend.domain.mypage.domain.service.FeedbackSaveService;
 import com.moing.backend.domain.mypage.exception.ExistingTeamException;
 import com.moing.backend.domain.team.domain.service.TeamGetService;
+import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.moing.backend.domain.teamMember.domain.service.TeamMemberGetService;
 import com.moing.backend.global.config.security.jwt.TokenUtil;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +25,6 @@ public class WithdrawUserCase {
     private final MemberGetService memberGetService;
     private final FeedbackSaveService feedbackSaveService;
     private final TokenUtil tokenUtil;
-    private final MemberDeleteService memberDeleteService;
-    private final TeamMemberGetService teamMemberGetService;
     private final TeamGetService teamGetService;
     private final Map<String, WithdrawProvider> withdrawProviders;
 
@@ -33,7 +32,7 @@ public class WithdrawUserCase {
         Member member = memberGetService.getMemberBySocialId(socialId);
         checkMemberIsNotPartOfAnyTeam(member);
         withdraw(providerInfo, withdrawRequest.getSocialToken());
-        memberDeleteService.deleteMember(member);
+        member.deleteMember();
         feedbackSaveService.saveFeedback(member, withdrawRequest);
         tokenUtil.expireRefreshToken(socialId);
     }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/entity/TeamMember.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/entity/TeamMember.java
@@ -39,7 +39,9 @@ public class TeamMember extends BaseTimeEntity {
 
     public void updateMember(Member member) {
         this.member = member;
-        member.getTeamMembers().add(this);
+        if (member != null) {
+            member.getTeamMembers().add(this);
+        }
     }
 
     public void deleteMember(Team team) {


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- member 삭제 소프트 삭제로 수정

## 변경 사항
- 기존에는 member삭제할 때 memberRepository를 이용해 아예 해당 칼럼을 삭제하는 방식이었음 (기획 요청) 
  -> member와 연관된 테이블이 많아 소프트 삭제로 수정
  - unique 제약조건 삭제
  - member을 조회할 때 삭제되지 않은 member을 조회하게 수정
 
## 코드 리뷰 시 참고 사항
https://github.com/Modagbul/MOING_Server_Release/blob/cfc0748e915a53b6ae1f8a38147a16174b455f38/src/main/java/com/moing/backend/domain/member/domain/repository/MemberCustomRepositoryImpl.java#L29-L53
이렇게 member을 조회할 때 삭제되지 않은 member을 조회하게 수정

member삭제할 때 소프트 삭제로 수정
https://github.com/Modagbul/MOING_Server_Release/blob/cfc0748e915a53b6ae1f8a38147a16174b455f38/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java#L165-L166
