### PR TITLE
Slack 알림 EventPublisher로 수정

### DIFF
--- a/src/main/java/com/moing/backend/domain/team/application/service/CreateTeamUserCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/CreateTeamUserCase.java
@@ -10,8 +10,9 @@ import com.moing.backend.domain.team.domain.service.TeamSaveService;
 import com.moing.backend.domain.teamMember.domain.service.TeamMemberSaveService;
 import com.moing.backend.domain.teamScore.application.mapper.TeamScoreMapper;
 import com.moing.backend.domain.teamScore.domain.service.TeamScoreSaveService;
-import com.moing.backend.global.util.SlackService;
+import com.moing.backend.global.config.slack.team.dto.TeamCreateEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -27,7 +28,7 @@ public class CreateTeamUserCase {
     private final TeamMapper teamMapper;
     private final TeamScoreSaveService teamScoreSaveService;
     private final TeamScoreMapper teamScoreMapper;
-    private final SlackService slackService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CreateTeamResponse createTeam(CreateTeamRequest createTeamRequest, String socialId){
         Member member = memberGetService.getMemberBySocialId(socialId);
@@ -38,7 +39,7 @@ public class CreateTeamUserCase {
         team.approveTeam();
         //====지워야 함 (테스트 용)=====
         teamScoreSaveService.save(teamScoreMapper.mapToTeamScore(team)); // 팀스코어 엔티티 생성
-        slackService.sendSlackTeamCreatedMessage(team.getName(), team.getLeaderId());
+        eventPublisher.publishEvent(new TeamCreateEvent(team.getName(), team.getLeaderId()));
         return new CreateTeamResponse(team.getTeamId());
     }
 }

--- a/src/main/java/com/moing/backend/global/config/slack/SlackConfig.java
+++ b/src/main/java/com/moing/backend/global/config/slack/SlackConfig.java
@@ -1,0 +1,14 @@
+package com.moing.backend.global.config.slack;
+
+import com.slack.api.Slack;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlackConfig {
+
+    @Bean
+    public Slack slackClient() {
+        return Slack.getInstance();
+    }
+}

--- a/src/main/java/com/moing/backend/global/config/slack/exception/ExceptionEventHandler.java
+++ b/src/main/java/com/moing/backend/global/config/slack/exception/ExceptionEventHandler.java
@@ -1,0 +1,21 @@
+package com.moing.backend.global.config.slack.exception;
+
+import com.moing.backend.global.config.slack.exception.dto.ExceptionEvent;
+import com.moing.backend.global.config.slack.util.WebhookUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ExceptionEventHandler {
+
+    private final WebhookUtil webhookUtil;
+
+    @Async("asyncTaskExecutor")
+    @EventListener
+    public void onExceptionEvent(ExceptionEvent event) {
+        webhookUtil.sendSlackAlertErrorLog(event.getRequest(), event.getException());
+    }
+}

--- a/src/main/java/com/moing/backend/global/config/slack/exception/dto/ExceptionEvent.java
+++ b/src/main/java/com/moing/backend/global/config/slack/exception/dto/ExceptionEvent.java
@@ -1,0 +1,14 @@
+package com.moing.backend.global.config.slack.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Getter
+@AllArgsConstructor
+public class ExceptionEvent {
+
+    private final HttpServletRequest request;
+    private final Exception exception;
+}

--- a/src/main/java/com/moing/backend/global/config/slack/team/TeamCreateHandler.java
+++ b/src/main/java/com/moing/backend/global/config/slack/team/TeamCreateHandler.java
@@ -1,0 +1,22 @@
+package com.moing.backend.global.config.slack.team;
+
+import com.moing.backend.global.config.slack.team.dto.TeamCreateEvent;
+import com.moing.backend.global.config.slack.util.WebhookUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class TeamCreateHandler {
+
+    private final WebhookUtil webhookUtil;
+
+    @Async("asyncTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onTeamCreateEvent(TeamCreateEvent event) {
+        webhookUtil.sendSlackTeamCreatedMessage(event.getTeamName(), event.getLeaderId());
+    }
+}

--- a/src/main/java/com/moing/backend/global/config/slack/team/dto/TeamCreateEvent.java
+++ b/src/main/java/com/moing/backend/global/config/slack/team/dto/TeamCreateEvent.java
@@ -1,0 +1,13 @@
+package com.moing.backend.global.config.slack.team.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TeamCreateEvent {
+
+    private final String teamName;
+    private final Long leaderId;
+
+}

--- a/src/main/java/com/moing/backend/global/config/slack/util/WebhookUtil.java
+++ b/src/main/java/com/moing/backend/global/config/slack/util/WebhookUtil.java
@@ -1,0 +1,10 @@
+package com.moing.backend.global.config.slack.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface WebhookUtil {
+
+    void sendSlackAlertErrorLog(HttpServletRequest request, Exception e);
+
+    void sendSlackTeamCreatedMessage(String teamName, Long leaderId);
+}

--- a/src/test/java/com/moing/backend/config/CommonControllerTest.java
+++ b/src/test/java/com/moing/backend/config/CommonControllerTest.java
@@ -8,7 +8,6 @@ import com.moing.backend.global.config.security.filter.JwtAccessDeniedHandler;
 import com.moing.backend.global.config.security.filter.JwtAuthenticationEntryPoint;
 import com.moing.backend.global.config.security.jwt.TokenUtil;
 import com.moing.backend.global.config.security.util.AuthenticationUtil;
-import com.moing.backend.global.util.SlackService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,9 +56,6 @@ public class CommonControllerTest {
 
     @MockBean
     public MemberGetService memberQueryService;
-
-    @MockBean
-    private SlackService slackService;
 
     @BeforeEach
     public void setUp(final WebApplicationContext context, final RestDocumentationContextProvider provider) throws Exception {


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- Slack 알림 EventPublisher로 수정

## 변경 사항
- Spring Events를 통해 주요 코드 실행 시 발생하는 이벤트에 대응하는 외부 로직을 처리. 이를 통해 핵심 서비스 로직과 외부 통신 로직의 결합도를 낮추고, 코드의 가독성과 유지보수성을 향상.
- Spring Events 구현을 비동기로 처리하여 시스템의 전반적인 효율성 향상. 이로써 외부 API 호출과 같은 비용이 큰 작업들이 기본 서비스 흐름을 방해하지 않도록 설계.
- 이전에는 팀 생성 서비스와 에러 처리 클래스 내에서 SlackService에 직접적인 의존성이 존재했으나, 이를 Spring의 EventPublisher로 관리하도록 변경. 이는 의존성 주입을 통해 더욱 유연한 코드 구조를 실현하며, 필요에 따라 다른 방식의 이벤트 처리 구현을 쉽게 통합할 수 있게 함.
