### PR TITLE
fix: 삭제 전 조회할 때 유저 닉네임 추가

### DIFF
--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/ReviewTeamResponse.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/ReviewTeamResponse.java
@@ -18,4 +18,5 @@ public class ReviewTeamResponse {
     private Long numOfMission;
     private Integer levelOfFire; //불꽃 레벨
     private Boolean isLeader;
+    private String memberName;
 }

--- a/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
+++ b/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
@@ -38,7 +38,7 @@ public class TeamMapper {
                 .build();
     }
 
-    public ReviewTeamResponse toReviewTeamResponse(Long numOfMission, Team team, boolean isLeader){
+    public ReviewTeamResponse toReviewTeamResponse(Long numOfMission, Team team, boolean isLeader, String memberName){
         return ReviewTeamResponse
                 .builder()
                 .teamId(team.getTeamId())
@@ -48,6 +48,7 @@ public class TeamMapper {
                 .duration(calculateDuration(team.getApprovalTime()))
                 .numOfMission(numOfMission)
                 .isLeader(isLeader)
+                .memberName(memberName)
                 .build();
     }
 

--- a/src/main/java/com/moing/backend/domain/team/application/service/ReviewTeamUseCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/ReviewTeamUseCase.java
@@ -27,6 +27,6 @@ public class ReviewTeamUseCase {
         Team team=teamGetService.getTeamByTeamId(teamId);
         Member member=memberGetService.getMemberBySocialId(socialId);
         boolean isLeader=checkLeaderUseCase.isTeamLeader(member, team);
-        return teamMapper.toReviewTeamResponse(missionQueryService.findMissionsCountByTeam(team.getTeamId()),team, isLeader);
+        return teamMapper.toReviewTeamResponse(missionQueryService.findMissionsCountByTeam(team.getTeamId()),team, isLeader, member.getNickName());
     }
 }

--- a/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
@@ -260,6 +260,7 @@ public class TeamControllerTest extends CommonControllerTest {
                 .numOfMission(90L)
                 .levelOfFire(3)
                 .isLeader(false)
+                .memberName("유저 닉네임")
                 .build();
 
         given(reviewTeamUseCase.reviewTeam(any(), any())).willReturn(output);
@@ -291,7 +292,8 @@ public class TeamControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.duration").description("소모임과 함께한 시간"),
                                         fieldWithPath("data.levelOfFire").description("소모임 불꽃 레벨"),
                                         fieldWithPath("data.numOfMission").description("미션 총 개수"),
-                                        fieldWithPath("data.isLeader").description("소모임장 여부")
+                                        fieldWithPath("data.isLeader").description("소모임장 여부"),
+                                        fieldWithPath("data.memberName").description("유저 닉네임")
                                 )
                         )
                 );


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- 삭제 전 조회할 때 유저 닉네임 추가 (클라이언트 요청)