### PR TITLE
Feat/alarm minsu

### DIFF
--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 public interface TeamMemberCustomRepository {
     List<Long> findMemberIdsByTeamId(Long teamId);
     Optional<List<String>> findFcmTokensByTeamIdAndMemberId(Long teamId, Long memberId);
-    Optional<List<String>> findFcmTokensByTeamId(Long teamId);
     List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long teamId);
     List<TeamMember> findTeamMemberByMemberId(Long memberId);
 }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
@@ -37,18 +37,8 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
                 .from(teamMember)
                 .where(teamMember.team.teamId.eq(teamId)
                         .and(teamMember.member.isNewUploadPush.eq(true))
-                        .and(teamMember.member.memberId.ne(memberId)))
-                .fetch();
-
-        return result.isEmpty() ? Optional.empty() : Optional.of(result);
-    }
-
-    @Override
-    public Optional<List<String>> findFcmTokensByTeamId(Long teamId) {
-        List<String> result = queryFactory.select(teamMember.member.fcmToken)
-                .from(teamMember)
-                .where(teamMember.team.teamId.eq(teamId)
-                        .and(teamMember.member.isNewUploadPush.eq(true)))
+                        .and(teamMember.member.memberId.ne(memberId))
+                        .and(teamMember.isDeleted.eq(false)))
                 .fetch();
 
         return result.isEmpty() ? Optional.empty() : Optional.of(result);

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
@@ -29,10 +29,6 @@ public class TeamMemberGetService {
         return teamMemberRepository.findFcmTokensByTeamIdAndMemberId(teamId, memberId);
     }
 
-    public Optional<List<String>> getFcmTokens(Long teamId) {
-        return teamMemberRepository.findFcmTokensByTeamId(teamId);
-    }
-
     public List<TeamMemberInfo> getTeamMemberInfo(Long teamId){
         return teamMemberRepository.findTeamMemberInfoByTeamId(teamId);
     }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 팀 탈퇴한 회원에게 알림 안가게 수정
- 미션 전송할 때 fcmService 의존성 삭제

## 변경 사항
1. 팀 탈퇴한 회원에게 알림 안가게 수정
https://github.com/Modagbul/MOING_Server_Release/blob/1c16c6af617d37ac0ec2a47189ee288e04be0cb8/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java#L34-L45

2. 미션 전송할 때 fcmService 의존성 삭제
알림 전송할 때 fcmService의 의존성을 지우고 비동기로 하기 위해 ApplicationEventPublisher 를 사용하고자 합니다!  게시글 생성할 때는 그 메서드를 이용해서 잘 되길래 같은 메서드를 호출하는 미션 sendNewMissionUploadAlarm()에서도 fcmService의 의존성을 지우고 ApplicationEventPublisher를 이용했습니다! 오류가 발생하지 않을 것 같긴 한데 혹시 모르니 이게 맞는지 확인해주시면 감사하겠습니다!

https://github.com/Modagbul/MOING_Server_Release/blob/1c16c6af617d37ac0ec2a47189ee288e04be0cb8/src/main/java/com/moing/backend/domain/mission/application/service/SendMissionCreateAlarmUseCase.java#L24-L42

++) 왜인지 sendMultipleDevices()는 잘 되는데 sendSingleDevice()는 오류가 발생해서^^... sendSingleDevice()는 테스트를 조금 더 해보고 바꾸려고 합니닷! (최종 목표는 fcmService 의존성 아예 지우기!)
