### PR TITLE
AlarmHistory 생성, 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,9 @@ dependencies {
 	//slack
 	implementation 'com.slack.api:slack-api-client:1.30.0'
 
+	//json
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+
 }
 
 tasks.named('test') {

--- a/src/docs/asciidoc/AlarmHistory-API.adoc
+++ b/src/docs/asciidoc/AlarmHistory-API.adoc
@@ -1,5 +1,8 @@
+[[AlarmHistory-API]]
+= AlarmHistory API
+
 [[AlarmHistory-알림-모아보기]]
-= AlarmHistory 알림 모아보기
+== AlarmHistory 알림 모아보기
 operation::alarm-history-controller-test/get_all_alarm_history[snippets='http-request,http-response,response-fields']
 
 == Type Category
@@ -22,3 +25,7 @@ operation::alarm-history-controller-test/get_all_alarm_history[snippets='http-re
 | 소모임 반려
 
 |===
+
+[[AlarmHistory-알림-단건-조회하기]]
+== AlarmHistory 알림 단건 조회하기
+operation::alarm-history-controller-test/read_alarm_history[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/AlarmHistory-API.adoc
+++ b/src/docs/asciidoc/AlarmHistory-API.adoc
@@ -1,5 +1,5 @@
 [[AlarmHistory-알림-모아보기]]
-== AlarmHistory 알림 모아보기
+= AlarmHistory 알림 모아보기
 operation::alarm-history-controller-test/get_all_alarm_history[snippets='http-request,http-response,response-fields']
 
 == Type Category

--- a/src/docs/asciidoc/AlarmHistory-API.adoc
+++ b/src/docs/asciidoc/AlarmHistory-API.adoc
@@ -1,0 +1,24 @@
+[[AlarmHistory-알림-모아보기]]
+== AlarmHistory 알림 모아보기
+operation::alarm-history-controller-test/get_all_alarm_history[snippets='http-request,http-response,response-fields']
+
+== Type Category
+|===
+| Category | Description
+
+| `NEW_UPLOAD`
+| 신규 업로드 알림
+
+| `FIRE`
+| 불던지기 알림
+
+| `REMIND`
+| 리마인드 알림
+
+| `APPROVE_TEAM`
+| 소모임 승인
+
+| `REJECT_TEAM`
+| 소모임 반려
+
+|===

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -14,6 +14,8 @@ include::Auth-API.adoc[]
 
 include::Mypage-API.adoc[]
 
+include::AlarmHistory-API.adoc[]
+
 include::Team-API.adoc[]
 
 include::Mission-API.adoc[]

--- a/src/main/java/com/moing/backend/domain/auth/application/service/apple/AppleSignInUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/apple/AppleSignInUseCase.java
@@ -10,14 +10,14 @@ import org.springframework.stereotype.Service;
 
 @Service("appleSignIn")
 @AllArgsConstructor
-public class AppleSignInUserCase implements SignInProvider {
+public class AppleSignInUseCase implements SignInProvider {
 
-    private final AppleTokenUserCase appleTokenUserCase;
+    private final AppleTokenUseCase appleTokenUseCase;
     private final MemberMapper memberMapper;
 
 
     public Member getUserData(String identityToken) {
-        Jws<Claims> oidcTokenJws = appleTokenUserCase.sigVerificationAndGetJws(identityToken);
+        Jws<Claims> oidcTokenJws = appleTokenUseCase.sigVerificationAndGetJws(identityToken);
 
         String socialId = oidcTokenJws.getBody().getSubject();
         String email = (String) oidcTokenJws.getBody().get("email");

--- a/src/main/java/com/moing/backend/domain/auth/application/service/apple/AppleTokenUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/apple/AppleTokenUseCase.java
@@ -19,7 +19,7 @@ import java.util.Base64;
 
 @Component
 @RequiredArgsConstructor
-public class AppleTokenUserCase {
+public class AppleTokenUseCase {
 
     @Value("${oauth2.apple.clientId}")
     private String appId;

--- a/src/main/java/com/moing/backend/domain/auth/application/service/apple/AppleWithdrawUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/apple/AppleWithdrawUseCase.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 @Service("appleWithdraw")
 @RequiredArgsConstructor
-public class AppleWithdrawUserCase implements WithdrawProvider {
+public class AppleWithdrawUseCase implements WithdrawProvider {
 
     @Value("${oauth2.apple.keyId}")
     private String keyId;

--- a/src/main/java/com/moing/backend/domain/auth/application/service/apple/utils/AppleClient.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/apple/utils/AppleClient.java
@@ -1,6 +1,6 @@
 package com.moing.backend.domain.auth.application.service.apple.utils;
 
-import com.moing.backend.global.util.FeignClientConfig;
+import com.moing.backend.global.utils.FeignClientConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/moing/backend/domain/auth/application/service/google/GoogleSignInUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/google/GoogleSignInUseCase.java
@@ -14,11 +14,11 @@ import reactor.core.publisher.Mono;
 
 @Service("googleSignIn")
 @RequiredArgsConstructor
-public class GoogleSignInUserCase implements SignInProvider {
+public class GoogleSignInUseCase implements SignInProvider {
 
     private final MemberMapper memberMapper;
     private final WebClient webClient;
-    private final GoogleTokenUserCase googleTokenUserCase;
+    private final GoogleTokenUseCase googleTokenUseCase;
 
     public Member getUserData(String accessToken) {
         GoogleUserResponse googleUserResponse = webClient.get()
@@ -30,7 +30,7 @@ public class GoogleSignInUserCase implements SignInProvider {
                 .block();
 
         if (googleUserResponse != null) {
-            googleTokenUserCase.verifyAccessToken(googleUserResponse.getAud());
+            googleTokenUseCase.verifyAccessToken(googleUserResponse.getAud());
             googleUserResponse.adaptResponse();
             return memberMapper.createGoogleMember(googleUserResponse);
         }

--- a/src/main/java/com/moing/backend/domain/auth/application/service/google/GoogleTokenUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/google/GoogleTokenUseCase.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 
 @Component
 @RequiredArgsConstructor
-public class GoogleTokenUserCase {
+public class GoogleTokenUseCase {
 
     @Value("${oauth2.google.appId}")
     private String appId;

--- a/src/main/java/com/moing/backend/domain/auth/application/service/google/GoogleWithdrawUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/google/GoogleWithdrawUseCase.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 
 @Service("googleWithdraw")
 @RequiredArgsConstructor
-public class GoogleWithdrawUserCase implements WithdrawProvider {
+public class GoogleWithdrawUseCase implements WithdrawProvider {
 
     private final GoogleClient googleClient;
 

--- a/src/main/java/com/moing/backend/domain/auth/application/service/google/utils/GoogleClient.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/google/utils/GoogleClient.java
@@ -1,6 +1,6 @@
 package com.moing.backend.domain.auth.application.service.google.utils;
 
-import com.moing.backend.global.util.FeignClientConfig;
+import com.moing.backend.global.utils.FeignClientConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/moing/backend/domain/auth/application/service/kakao/KakaoSignInUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/kakao/KakaoSignInUseCase.java
@@ -14,15 +14,15 @@ import reactor.core.publisher.Mono;
 
 @Service("kakaoSignIn")
 @RequiredArgsConstructor
-public class KakaoSignInUserCase implements SignInProvider {
+public class KakaoSignInUseCase implements SignInProvider {
 
     private final WebClient webClient;
     private final MemberMapper memberMapper;
-    private final KakaoTokenUserCase kakaoTokenUserCase;
+    private final KakaoTokenUseCase kakaoTokenUseCase;
 
     public Member getUserData(String accessToken) {
 
-        kakaoTokenUserCase.verifyAccessToken(accessToken);
+        kakaoTokenUseCase.verifyAccessToken(accessToken);
 
 
         KakaoUserResponse kakaoUserResponse = webClient.get()

--- a/src/main/java/com/moing/backend/domain/auth/application/service/kakao/KakaoTokenUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/kakao/KakaoTokenUseCase.java
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
-public class KakaoTokenUserCase {
+public class KakaoTokenUseCase {
 
     @Value("${oauth2.kakao.appId}")
     private String appId;

--- a/src/main/java/com/moing/backend/domain/auth/application/service/kakao/KakaoWithdrawUseCase.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/kakao/KakaoWithdrawUseCase.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 
 @Service("kakaoWithdraw")
 @RequiredArgsConstructor
-public class KakaoWithdrawUserCase implements WithdrawProvider {
+public class KakaoWithdrawUseCase implements WithdrawProvider {
 
     private final KakaoClient kakaoClient;
 

--- a/src/main/java/com/moing/backend/domain/auth/application/service/kakao/utils/KakaoClient.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/service/kakao/utils/KakaoClient.java
@@ -1,6 +1,6 @@
 package com.moing.backend.domain.auth.application.service.kakao.utils;
 
-import com.moing.backend.global.util.FeignClientConfig;
+import com.moing.backend.global.utils.FeignClientConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/src/main/java/com/moing/backend/domain/board/application/mapper/BoardMapper.java
+++ b/src/main/java/com/moing/backend/domain/board/application/mapper/BoardMapper.java
@@ -34,12 +34,13 @@ public class BoardMapper {
         return board;
     }
 
-    public GetBoardDetailResponse toBoardDetail(Board board, boolean isWriter) {
+    public GetBoardDetailResponse toBoardDetail(Board board, boolean isWriter, boolean writerIsDeleted) {
+        String nickName = writerIsDeleted ? "(알 수 없음)" : board.getWriterNickName();
         return GetBoardDetailResponse.builder()
                 .boardId(board.getBoardId())
                 .title(board.getTitle())
                 .content(board.getContent())
-                .writerNickName(board.getWriterNickName())
+                .writerNickName(nickName)
                 .writerIsLeader(board.isLeader())
                 .writerProfileImage(board.getWriterProfileImage())
                 .createdDate(getFormattedDate(board.getCreatedDate()))

--- a/src/main/java/com/moing/backend/domain/board/application/service/CreateBoardUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/CreateBoardUseCase.java
@@ -6,9 +6,14 @@ import com.moing.backend.domain.board.application.mapper.BoardMapper;
 import com.moing.backend.domain.board.domain.entity.Board;
 import com.moing.backend.domain.board.domain.service.BoardSaveService;
 import com.moing.backend.domain.boardRead.application.service.CreateBoardReadUseCase;
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import com.moing.backend.domain.history.domain.entity.PagePath;
+import com.moing.backend.domain.history.domain.service.AlarmHistorySaveService;
 import com.moing.backend.domain.team.application.service.CheckLeaderUseCase;
 import com.moing.backend.global.response.BaseServiceResponse;
-import com.moing.backend.global.util.BaseService;
+import com.moing.backend.global.utils.BaseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -41,6 +46,7 @@ public class CreateBoardUseCase {
 
         //3. 알림 보내기 - 공지인 경우
         sendBoardAlarmUseCase.sendNewUploadAlarm(data, board);
+
         return new CreateBoardResponse(board.getBoardId());
     }
 }

--- a/src/main/java/com/moing/backend/domain/board/application/service/DeleteBoardUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/DeleteBoardUseCase.java
@@ -3,7 +3,7 @@ package com.moing.backend.domain.board.application.service;
 import com.moing.backend.domain.board.domain.service.BoardDeleteService;
 import com.moing.backend.domain.board.exception.NotAuthByBoardException;
 import com.moing.backend.global.response.BaseBoardServiceResponse;
-import com.moing.backend.global.util.BaseBoardService;
+import com.moing.backend.global.utils.BaseBoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/moing/backend/domain/board/application/service/GetBoardUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/GetBoardUseCase.java
@@ -8,7 +8,7 @@ import com.moing.backend.domain.boardRead.application.service.CreateBoardReadUse
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.member.domain.service.MemberGetService;
 import com.moing.backend.global.response.BaseBoardServiceResponse;
-import com.moing.backend.global.util.BaseBoardService;
+import com.moing.backend.global.utils.BaseBoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -35,7 +35,7 @@ public class GetBoardUseCase {
         BaseBoardServiceResponse data = baseBoardService.getCommonData(socialId, teamId, boardId);
         // 2. 읽음 처리
         createBoardReadUseCase.createBoardRead(data.getTeam(), data.getMember(), data.getBoard());
-        return boardMapper.toBoardDetail(data.getBoard(), data.getTeamMember() == data.getBoard().getTeamMember());
+        return boardMapper.toBoardDetail(data.getBoard(), data.getTeamMember() == data.getBoard().getTeamMember(), data.getBoard().getTeamMember().isDeleted());
     }
 
     /**

--- a/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
@@ -1,18 +1,27 @@
 package com.moing.backend.domain.board.application.service;
 
 import com.moing.backend.domain.board.domain.entity.Board;
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import com.moing.backend.domain.history.domain.entity.PagePath;
+import com.moing.backend.domain.history.domain.service.AlarmHistorySaveService;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.teamMember.domain.service.TeamMemberGetService;
 import com.moing.backend.global.config.fcm.dto.event.FcmEvent;
 import com.moing.backend.global.response.BaseServiceResponse;
 import lombok.RequiredArgsConstructor;
+import net.minidev.json.JSONObject;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.moing.backend.global.config.fcm.constant.NewNoticeUploadMessage.NEW_NOTICE_UPLOAD_MESSAGE;
 
@@ -23,6 +32,8 @@ public class SendBoardAlarmUseCase {
 
     private final TeamMemberGetService teamMemberGetService;
     private final ApplicationEventPublisher eventPublisher;
+    private final AlarmHistorySaveService alarmHistorySaveService;
+    private final AlarmHistoryMapper alarmHistoryMapper;
 
     public void sendNewUploadAlarm(BaseServiceResponse baseServiceResponse, Board board) {
         Member member = baseServiceResponse.getMember();
@@ -31,11 +42,47 @@ public class SendBoardAlarmUseCase {
         if (board.isNotice() && member.isNewUploadPush()) {
             String title = NEW_NOTICE_UPLOAD_MESSAGE.title(team.getName());
             String body = NEW_NOTICE_UPLOAD_MESSAGE.body(board.getTitle());
-            Optional<List<String>> fcmTokens = teamMemberGetService.getFcmTokensExceptMe(team.getTeamId(), member.getMemberId());
-            if (fcmTokens.isPresent() && !fcmTokens.get().isEmpty()) {
-                eventPublisher.publishEvent(new FcmEvent(title, body, fcmTokens.get()));
+            Optional<List<MemberIdAndToken>> memberIdAndTokens = teamMemberGetService.getMemberInfoExceptMe(team.getTeamId(), member.getMemberId());
+            if (memberIdAndTokens.isPresent() && !memberIdAndTokens.get().isEmpty()) {
+                //알림 보내기
+                List<String> fcmTokens = getFcmTokens(memberIdAndTokens);
+                eventPublisher.publishEvent(new FcmEvent(title, body, fcmTokens));
+                //알림 저장하기
+                List<Long> memberIds = getMemberIds(memberIdAndTokens);
+                String idInfo = createIdInfo(team.getTeamId(), board.getBoardId());
+                saveAlarmHistory(idInfo, memberIds, title, body, team.getName());
             }
         }
     }
+
+    private List<String> getFcmTokens(Optional<List<MemberIdAndToken>> memberIdAndTokens) {
+        return memberIdAndTokens.map(list -> list.stream()
+                        .map(MemberIdAndToken::getFcmToken)
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    private List<Long> getMemberIds(Optional<List<MemberIdAndToken>> memberIdAndTokens) {
+        return memberIdAndTokens.map(list -> list.stream()
+                        .map(MemberIdAndToken::getMemberId)
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    private void saveAlarmHistory(String idInfo, List<Long> memberIds, String title, String body, String teamName) {
+        List<AlarmHistory> alarmHistories = memberIds.stream()
+                .map(memberId -> alarmHistoryMapper.toAlarmHistory(AlarmType.NEW_UPLOAD, PagePath.NOTICE_PATH.getValue(), idInfo, memberId, title, body, teamName))
+                .collect(Collectors.toList());
+
+        alarmHistorySaveService.saveAlarmHistory(alarmHistories); // 여기서 saveAll은 일괄 삽입을 처리하는 메서드입니다.
+    }
+
+    private String createIdInfo(Long teamId, Long boardId) {
+        JSONObject jo = new JSONObject();
+        jo.put("teamId", teamId);
+        jo.put("boardId", boardId);
+        return jo.toJSONString();
+    }
+
 }
 

--- a/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
@@ -39,15 +39,18 @@ public class SendBoardAlarmUseCase {
         Member member = baseServiceResponse.getMember();
         Team team = baseServiceResponse.getTeam();
 
-        if (board.isNotice() && member.isNewUploadPush()) {
+        if (board.isNotice()) {
+            System.out.println("공지인 경우");
             String title = NEW_NOTICE_UPLOAD_MESSAGE.title(team.getName());
             String body = NEW_NOTICE_UPLOAD_MESSAGE.body(board.getTitle());
             Optional<List<MemberIdAndToken>> memberIdAndTokens = teamMemberGetService.getMemberInfoExceptMe(team.getTeamId(), member.getMemberId());
             if (memberIdAndTokens.isPresent() && !memberIdAndTokens.get().isEmpty()) {
                 //알림 보내기
+                System.out.println("###알림 보내기###");
                 List<String> fcmTokens = getFcmTokens(memberIdAndTokens);
                 eventPublisher.publishEvent(new FcmEvent(title, body, fcmTokens));
                 //알림 저장하기
+                System.out.println("###알림 저장###");
                 List<Long> memberIds = getMemberIds(memberIdAndTokens);
                 String idInfo = createIdInfo(team.getTeamId(), board.getBoardId());
                 saveAlarmHistory(idInfo, memberIds, title, body, team.getName());

--- a/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
@@ -3,10 +3,9 @@ package com.moing.backend.domain.board.application.service;
 import com.moing.backend.domain.board.domain.entity.Board;
 import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
 import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
-import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.application.service.SaveMultiAlarmHistoryUseCase;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
 import com.moing.backend.domain.history.domain.entity.PagePath;
-import com.moing.backend.domain.history.domain.service.AlarmHistorySaveService;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.teamMember.domain.service.TeamMemberGetService;
@@ -18,10 +17,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.moing.backend.global.config.fcm.constant.NewNoticeUploadMessage.NEW_NOTICE_UPLOAD_MESSAGE;
 
@@ -32,7 +29,7 @@ public class SendBoardAlarmUseCase {
 
     private final TeamMemberGetService teamMemberGetService;
     private final ApplicationEventPublisher eventPublisher;
-    private final AlarmHistorySaveService alarmHistorySaveService;
+    private final SaveMultiAlarmHistoryUseCase saveAlarmHistory;
     private final AlarmHistoryMapper alarmHistoryMapper;
 
     public void sendNewUploadAlarm(BaseServiceResponse baseServiceResponse, Board board) {
@@ -45,36 +42,12 @@ public class SendBoardAlarmUseCase {
             Optional<List<MemberIdAndToken>> memberIdAndTokens = teamMemberGetService.getMemberInfoExceptMe(team.getTeamId(), member.getMemberId());
             if (memberIdAndTokens.isPresent() && !memberIdAndTokens.get().isEmpty()) {
                 //알림 보내기
-                List<String> fcmTokens = getFcmTokens(memberIdAndTokens);
+                List<String> fcmTokens = alarmHistoryMapper.getFcmTokens(memberIdAndTokens);
                 eventPublisher.publishEvent(new FcmEvent(title, body, fcmTokens));
                 //알림 저장하기
-                List<Long> memberIds = getMemberIds(memberIdAndTokens);
-                String idInfo = createIdInfo(team.getTeamId(), board.getBoardId());
-                saveAlarmHistory(idInfo, memberIds, title, body, team.getName());
+                saveAlarmHistory.saveAlarmHistories(memberIdAndTokens, createIdInfo(team.getTeamId(), board.getBoardId()), title, body, team.getName(), AlarmType.NEW_UPLOAD, PagePath.NOTICE_PATH.getValue());
             }
         }
-    }
-
-    private List<String> getFcmTokens(Optional<List<MemberIdAndToken>> memberIdAndTokens) {
-        return memberIdAndTokens.map(list -> list.stream()
-                        .map(MemberIdAndToken::getFcmToken)
-                        .collect(Collectors.toList()))
-                .orElse(Collections.emptyList());
-    }
-
-    private List<Long> getMemberIds(Optional<List<MemberIdAndToken>> memberIdAndTokens) {
-        return memberIdAndTokens.map(list -> list.stream()
-                        .map(MemberIdAndToken::getMemberId)
-                        .collect(Collectors.toList()))
-                .orElse(Collections.emptyList());
-    }
-
-    private void saveAlarmHistory(String idInfo, List<Long> memberIds, String title, String body, String teamName) {
-        List<AlarmHistory> alarmHistories = memberIds.stream()
-                .map(memberId -> alarmHistoryMapper.toAlarmHistory(AlarmType.NEW_UPLOAD, PagePath.NOTICE_PATH.getValue(), idInfo, memberId, title, body, teamName))
-                .collect(Collectors.toList());
-
-        alarmHistorySaveService.saveAlarmHistory(alarmHistories); // 여기서 saveAll은 일괄 삽입을 처리하는 메서드입니다.
     }
 
     private String createIdInfo(Long teamId, Long boardId) {

--- a/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
@@ -40,17 +40,14 @@ public class SendBoardAlarmUseCase {
         Team team = baseServiceResponse.getTeam();
 
         if (board.isNotice()) {
-            System.out.println("공지인 경우");
             String title = NEW_NOTICE_UPLOAD_MESSAGE.title(team.getName());
             String body = NEW_NOTICE_UPLOAD_MESSAGE.body(board.getTitle());
             Optional<List<MemberIdAndToken>> memberIdAndTokens = teamMemberGetService.getMemberInfoExceptMe(team.getTeamId(), member.getMemberId());
             if (memberIdAndTokens.isPresent() && !memberIdAndTokens.get().isEmpty()) {
                 //알림 보내기
-                System.out.println("###알림 보내기###");
                 List<String> fcmTokens = getFcmTokens(memberIdAndTokens);
                 eventPublisher.publishEvent(new FcmEvent(title, body, fcmTokens));
                 //알림 저장하기
-                System.out.println("###알림 저장###");
                 List<Long> memberIds = getMemberIds(memberIdAndTokens);
                 String idInfo = createIdInfo(team.getTeamId(), board.getBoardId());
                 saveAlarmHistory(idInfo, memberIds, title, body, team.getName());

--- a/src/main/java/com/moing/backend/domain/board/application/service/UpdateBoardUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/UpdateBoardUseCase.java
@@ -4,7 +4,7 @@ import com.moing.backend.domain.board.application.dto.request.UpdateBoardRequest
 import com.moing.backend.domain.board.application.dto.response.UpdateBoardResponse;
 import com.moing.backend.domain.board.exception.NotAuthByBoardException;
 import com.moing.backend.global.response.BaseBoardServiceResponse;
-import com.moing.backend.global.util.BaseBoardService;
+import com.moing.backend.global.utils.BaseBoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/moing/backend/domain/board/domain/entity/Board.java
+++ b/src/main/java/com/moing/backend/domain/board/domain/entity/Board.java
@@ -6,7 +6,7 @@ import com.moing.backend.domain.boardRead.domain.entity.BoardRead;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.moing.backend.global.entity.BaseTimeEntity;
-import com.moing.backend.global.util.AesConverter;
+import com.moing.backend.global.utils.AesConverter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/moing/backend/domain/boardComment/application/service/CreateBoardCommentUseCase.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/service/CreateBoardCommentUseCase.java
@@ -7,7 +7,7 @@ import com.moing.backend.domain.boardComment.domain.entity.BoardComment;
 import com.moing.backend.domain.boardComment.domain.service.BoardCommentSaveService;
 import com.moing.backend.domain.team.application.service.CheckLeaderUseCase;
 import com.moing.backend.global.response.BaseBoardServiceResponse;
-import com.moing.backend.global.util.BaseBoardService;
+import com.moing.backend.global.utils.BaseBoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/moing/backend/domain/boardComment/application/service/DeleteBoardCommentUseCase.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/service/DeleteBoardCommentUseCase.java
@@ -5,7 +5,7 @@ import com.moing.backend.domain.boardComment.domain.service.BoardCommentDeleteSe
 import com.moing.backend.domain.boardComment.domain.service.BoardCommentGetService;
 import com.moing.backend.domain.boardComment.exception.NotAuthByBoardCommentException;
 import com.moing.backend.global.response.BaseBoardServiceResponse;
-import com.moing.backend.global.util.BaseBoardService;
+import com.moing.backend.global.utils.BaseBoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/moing/backend/domain/boardComment/application/service/GetBoardCommentUseCase.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/service/GetBoardCommentUseCase.java
@@ -3,7 +3,7 @@ package com.moing.backend.domain.boardComment.application.service;
 import com.moing.backend.domain.boardComment.application.dto.response.GetBoardCommentResponse;
 import com.moing.backend.domain.boardComment.domain.service.BoardCommentGetService;
 import com.moing.backend.global.response.BaseBoardServiceResponse;
-import com.moing.backend.global.util.BaseBoardService;
+import com.moing.backend.global.utils.BaseBoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/moing/backend/domain/boardComment/domain/entity/BoardComment.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/domain/entity/BoardComment.java
@@ -3,7 +3,7 @@ package com.moing.backend.domain.boardComment.domain.entity;
 import com.moing.backend.domain.board.domain.entity.Board;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.moing.backend.global.entity.BaseTimeEntity;
-import com.moing.backend.global.util.AesConverter;
+import com.moing.backend.global.utils.AesConverter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/moing/backend/domain/history/application/dto/response/GetAlarmHistoryResponse.java
+++ b/src/main/java/com/moing/backend/domain/history/application/dto/response/GetAlarmHistoryResponse.java
@@ -3,6 +3,7 @@ package com.moing.backend.domain.history.application.dto.response;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -10,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class GetAlarmHistoryResponse {
 
     private Long alarmHistoryId;
@@ -26,7 +28,7 @@ public class GetAlarmHistoryResponse {
 
     private String name;
 
-    private boolean isRead;
+    private Boolean isRead;
 
     private String createdDate;
 

--- a/src/main/java/com/moing/backend/domain/history/application/dto/response/GetAlarmHistoryResponse.java
+++ b/src/main/java/com/moing/backend/domain/history/application/dto/response/GetAlarmHistoryResponse.java
@@ -1,0 +1,60 @@
+package com.moing.backend.domain.history.application.dto.response;
+
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@AllArgsConstructor
+public class GetAlarmHistoryResponse {
+
+    private Long alarmHistoryId;
+
+    private AlarmType type;
+
+    private String path;
+
+    private String idInfo;
+
+    private String title;
+
+    private String body;
+
+    private String name;
+
+    private boolean isRead;
+
+    private String createdDate;
+
+    @QueryProjection
+    public GetAlarmHistoryResponse(Long alarmHistoryId, AlarmType type, String path, String idInfo, String title, String body, String name, boolean isRead, LocalDateTime createdDate) {
+        this.alarmHistoryId = alarmHistoryId;
+        this.type = type;
+        this.path = path;
+        this.idInfo = idInfo;
+        this.title = title;
+        this.body = body;
+        this.name = name;
+        this.isRead = isRead;
+        this.createdDate = formatCreatedDate(createdDate);
+    }
+
+    public String formatCreatedDate(LocalDateTime createdDate) {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+
+        LocalDateTime midnightOfCreatedDate = createdDate.toLocalDate().atStartOfDay();
+
+        if (currentDateTime.isAfter(midnightOfCreatedDate.plusDays(1))) {
+            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("M월 d일");
+            return midnightOfCreatedDate.plusDays(1).format(dateFormatter);
+        } else {
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("a h:mm");
+            return currentDateTime.format(timeFormatter);
+        }
+    }
+
+}

--- a/src/main/java/com/moing/backend/domain/history/application/dto/response/MemberIdAndToken.java
+++ b/src/main/java/com/moing/backend/domain/history/application/dto/response/MemberIdAndToken.java
@@ -1,0 +1,17 @@
+package com.moing.backend.domain.history.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberIdAndToken {
+
+    private String fcmToken;
+    private Long memberId;
+
+}

--- a/src/main/java/com/moing/backend/domain/history/application/dto/response/MemberIdAndToken.java
+++ b/src/main/java/com/moing/backend/domain/history/application/dto/response/MemberIdAndToken.java
@@ -3,12 +3,14 @@ package com.moing.backend.domain.history.application.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class MemberIdAndToken {
 
     private String fcmToken;

--- a/src/main/java/com/moing/backend/domain/history/application/mapper/AlarmHistoryMapper.java
+++ b/src/main/java/com/moing/backend/domain/history/application/mapper/AlarmHistoryMapper.java
@@ -1,12 +1,15 @@
 package com.moing.backend.domain.history.application.mapper;
 
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
 import com.moing.backend.domain.history.domain.entity.AlarmHistory;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
-import com.moing.backend.domain.member.domain.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import javax.persistence.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -24,4 +27,25 @@ public class AlarmHistoryMapper {
                 .isRead(false)
                 .build();
     }
+
+    public List<String> getFcmTokens(Optional<List<MemberIdAndToken>> memberIdAndTokens) {
+        return memberIdAndTokens.map(list -> list.stream()
+                        .map(MemberIdAndToken::getFcmToken)
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    public List<Long> getMemberIds(Optional<List<MemberIdAndToken>> memberIdAndTokens) {
+        return memberIdAndTokens.map(list -> list.stream()
+                        .map(MemberIdAndToken::getMemberId)
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    public List<AlarmHistory> getAlarmHistories(String idInfo, List<Long> memberIds, String title, String body, String teamName, AlarmType alarmType, String path) {
+        return memberIds.stream()
+                .map(memberId -> toAlarmHistory(alarmType, path, idInfo, memberId, title, body, teamName))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/moing/backend/domain/history/application/mapper/AlarmHistoryMapper.java
+++ b/src/main/java/com/moing/backend/domain/history/application/mapper/AlarmHistoryMapper.java
@@ -1,0 +1,27 @@
+package com.moing.backend.domain.history.application.mapper;
+
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import com.moing.backend.domain.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.*;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmHistoryMapper {
+
+    public AlarmHistory toAlarmHistory(AlarmType type, String path, String idInfo, Long receiverId, String title, String body, String name){
+        return AlarmHistory.builder()
+                .type(type)
+                .path(path)
+                .idInfo(idInfo)
+                .receiverId(receiverId)
+                .title(title)
+                .body(body)
+                .name(name)
+                .isRead(false)
+                .build();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/application/service/GetAlarmHistoryUseCase.java
+++ b/src/main/java/com/moing/backend/domain/history/application/service/GetAlarmHistoryUseCase.java
@@ -1,0 +1,26 @@
+package com.moing.backend.domain.history.application.service;
+
+import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+import com.moing.backend.domain.history.domain.service.AlarmHistoryGetService;
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.member.domain.service.MemberGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetAlarmHistoryUseCase {
+
+    private final MemberGetService memberGetService;
+    private final AlarmHistoryGetService alarmHistoryGetService;
+
+    /**
+     * 알림 히스토리 조회
+     */
+    public List<GetAlarmHistoryResponse> getAllAlarmHistories(String socialId) {
+        Member member = memberGetService.getMemberBySocialId(socialId);
+        return alarmHistoryGetService.getAlarmHistories(member.getMemberId());
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/application/service/ReadAlarmHistoryUseCase.java
+++ b/src/main/java/com/moing/backend/domain/history/application/service/ReadAlarmHistoryUseCase.java
@@ -1,0 +1,30 @@
+package com.moing.backend.domain.history.application.service;
+
+import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.domain.service.AlarmHistoryGetService;
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.member.domain.service.MemberGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReadAlarmHistoryUseCase {
+
+    private final MemberGetService memberGetService;
+    private final AlarmHistoryGetService alarmHistoryGetService;
+
+    /**
+     * 알림 히스토리 읽기
+     */
+    @Transactional
+    public void readAlarmHistory(String socialId, Long alarmHistoryId) {
+        Member member = memberGetService.getMemberBySocialId(socialId);
+        AlarmHistory alarmHistory=alarmHistoryGetService.getAlarmHistory(alarmHistoryId, member.getMemberId());
+        alarmHistory.readAlarmHistory();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/application/service/SaveMultiAlarmHistoryUseCase.java
+++ b/src/main/java/com/moing/backend/domain/history/application/service/SaveMultiAlarmHistoryUseCase.java
@@ -1,0 +1,28 @@
+package com.moing.backend.domain.history.application.service;
+
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import com.moing.backend.domain.history.domain.service.AlarmHistorySaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SaveMultiAlarmHistoryUseCase {
+
+    private final AlarmHistoryMapper alarmHistoryMapper;
+    private final AlarmHistorySaveService alarmHistorySaveService;
+
+    @Async
+    public void saveAlarmHistories(Optional<List<MemberIdAndToken>> memberIdAndTokens, String idInfo, String title, String body, String name, AlarmType alarmType, String path) {
+        List<Long> memberIds = alarmHistoryMapper.getMemberIds(memberIdAndTokens);
+        List<AlarmHistory> alarmHistories = alarmHistoryMapper.getAlarmHistories(idInfo, memberIds, title, body, name, alarmType, path);
+        alarmHistorySaveService.saveAlarmHistories(alarmHistories);
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/application/service/SaveSingleAlarmHistoryUseCase.java
+++ b/src/main/java/com/moing/backend/domain/history/application/service/SaveSingleAlarmHistoryUseCase.java
@@ -1,0 +1,23 @@
+package com.moing.backend.domain.history.application.service;
+
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import com.moing.backend.domain.history.domain.service.AlarmHistorySaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SaveSingleAlarmHistoryUseCase {
+
+    private final AlarmHistoryMapper alarmHistoryMapper;
+    private final AlarmHistorySaveService alarmHistorySaveService;
+
+    @Async
+    public void saveAlarmHistory(String fcmToken, Long memberId, String idInfo, String title, String body, String name, AlarmType alarmType, String path) {
+        AlarmHistory alarmHistory = alarmHistoryMapper.toAlarmHistory(alarmType, path, idInfo, memberId, title, body, name);
+        alarmHistorySaveService.saveAlarmHistory(alarmHistory);
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/entity/AlarmHistory.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/entity/AlarmHistory.java
@@ -1,0 +1,45 @@
+package com.moing.backend.domain.history.domain.entity;
+
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.global.entity.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlarmHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "alarm_history_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AlarmType type;
+
+    @Column(nullable = false)
+    private String path;
+
+    private String idInfo;
+
+    private Long receiverId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String body;
+
+    @Column(nullable = false)
+    private String name;
+
+    private boolean isRead;
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/entity/AlarmHistory.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/entity/AlarmHistory.java
@@ -42,4 +42,8 @@ public class AlarmHistory extends BaseTimeEntity {
     private String name;
 
     private boolean isRead;
+
+    public void readAlarmHistory(){
+        this.isRead=true;
+    }
 }

--- a/src/main/java/com/moing/backend/domain/history/domain/entity/AlarmType.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/entity/AlarmType.java
@@ -1,0 +1,12 @@
+package com.moing.backend.domain.history.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum AlarmType {
+    NEW_UPLOAD,
+    FIRE,
+    REMIND,
+    APPROVE_TEAM,
+    REJECT_TEAM
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/entity/PagePath.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/entity/PagePath.java
@@ -1,0 +1,21 @@
+package com.moing.backend.domain.history.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PagePath {
+
+    NOTICE_PATH("/post/detail"),
+
+    MISSION_PATH("/missions/prove"),
+
+    MISSION_ALL_PTAH("/missions"),
+
+    HOME_PATH("/home");
+
+
+    private final String value;
+
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepository.java
@@ -1,0 +1,10 @@
+package com.moing.backend.domain.history.domain.repository;
+
+import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+
+import java.util.List;
+
+public interface AlarmHistoryCustomRepository {
+
+    List<GetAlarmHistoryResponse> findAlarmHistoriesByMemberId(Long memberId);
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepositoryImpl.java
@@ -2,12 +2,16 @@ package com.moing.backend.domain.history.domain.repository;
 
 import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
 import com.moing.backend.domain.history.application.dto.response.QGetAlarmHistoryResponse;
+import com.moing.backend.domain.team.domain.constant.ApprovalStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.impl.JPAUpdateClause;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.moing.backend.domain.history.domain.entity.QAlarmHistory.alarmHistory;
+import static com.moing.backend.domain.team.domain.entity.QTeam.team;
 
 public class AlarmHistoryCustomRepositoryImpl implements AlarmHistoryCustomRepository {
 

--- a/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.moing.backend.domain.history.domain.repository;
+
+import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+import com.moing.backend.domain.history.application.dto.response.QGetAlarmHistoryResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.moing.backend.domain.history.domain.entity.QAlarmHistory.alarmHistory;
+
+public class AlarmHistoryCustomRepositoryImpl implements AlarmHistoryCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public AlarmHistoryCustomRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<GetAlarmHistoryResponse> findAlarmHistoriesByMemberId(Long memberId) {
+        return queryFactory.select(new QGetAlarmHistoryResponse(alarmHistory.id,
+                        alarmHistory.type,
+                        alarmHistory.path,
+                        alarmHistory.idInfo,
+                        alarmHistory.title,
+                        alarmHistory.body,
+                        alarmHistory.name,
+                        alarmHistory.isRead,
+                        alarmHistory.createdDate))
+                .from(alarmHistory)
+                .where(alarmHistory.receiverId.eq(memberId))
+                .orderBy(alarmHistory.createdDate.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryRepository.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryRepository.java
@@ -3,5 +3,9 @@ package com.moing.backend.domain.history.domain.repository;
 import com.moing.backend.domain.history.domain.entity.AlarmHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AlarmHistoryRepository extends JpaRepository<AlarmHistory, Long>, AlarmHistoryCustomRepository {
+
+    Optional<AlarmHistory> findAlarmHistoryByIdAndReceiverId(Long id, Long receiverId);
 }

--- a/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryRepository.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.moing.backend.domain.history.domain.repository;
+
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmHistoryRepository extends JpaRepository<AlarmHistory, Long>, AlarmHistoryCustomRepository {
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistoryGetService.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistoryGetService.java
@@ -1,0 +1,21 @@
+package com.moing.backend.domain.history.domain.service;
+
+import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+import com.moing.backend.domain.history.domain.repository.AlarmHistoryRepository;
+import com.moing.backend.global.annotation.DomainService;
+import lombok.RequiredArgsConstructor;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@DomainService
+@Transactional
+@RequiredArgsConstructor
+public class AlarmHistoryGetService {
+
+    private final AlarmHistoryRepository alarmHistoryRepository;
+
+    public List<GetAlarmHistoryResponse> getAlarmHistories(Long memberId){
+        return alarmHistoryRepository.findAlarmHistoriesByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistoryGetService.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistoryGetService.java
@@ -22,6 +22,6 @@ public class AlarmHistoryGetService {
     }
 
     public AlarmHistory getAlarmHistory(Long alarmHistoryId, Long memberId){
-        return alarmHistoryRepository.findAlarmHistoryByIdAndReceiverId(alarmHistoryId, alarmHistoryId).orElseThrow(NotFoundAlarmHistoryException::new);
+        return alarmHistoryRepository.findAlarmHistoryByIdAndReceiverId(alarmHistoryId, memberId).orElseThrow(NotFoundAlarmHistoryException::new);
     }
 }

--- a/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistoryGetService.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistoryGetService.java
@@ -1,7 +1,9 @@
 package com.moing.backend.domain.history.domain.service;
 
 import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
 import com.moing.backend.domain.history.domain.repository.AlarmHistoryRepository;
+import com.moing.backend.domain.history.exception.NotFoundAlarmHistoryException;
 import com.moing.backend.global.annotation.DomainService;
 import lombok.RequiredArgsConstructor;
 
@@ -17,5 +19,9 @@ public class AlarmHistoryGetService {
 
     public List<GetAlarmHistoryResponse> getAlarmHistories(Long memberId){
         return alarmHistoryRepository.findAlarmHistoriesByMemberId(memberId);
+    }
+
+    public AlarmHistory getAlarmHistory(Long alarmHistoryId, Long memberId){
+        return alarmHistoryRepository.findAlarmHistoryByIdAndReceiverId(alarmHistoryId, alarmHistoryId).orElseThrow(NotFoundAlarmHistoryException::new);
     }
 }

--- a/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistorySaveService.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistorySaveService.java
@@ -15,8 +15,12 @@ public class AlarmHistorySaveService {
 
     private final AlarmHistoryRepository alarmHistoryRepository;
 
-    public void saveAlarmHistory(List<AlarmHistory> alarmHistories){
+    public void saveAlarmHistories(List<AlarmHistory> alarmHistories){
         alarmHistoryRepository.saveAll(alarmHistories);
+    }
+
+    public void saveAlarmHistory(AlarmHistory alarmHistory){
+        alarmHistoryRepository.save(alarmHistory);
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistorySaveService.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/service/AlarmHistorySaveService.java
@@ -1,0 +1,22 @@
+package com.moing.backend.domain.history.domain.service;
+
+import com.moing.backend.domain.history.domain.entity.AlarmHistory;
+import com.moing.backend.domain.history.domain.repository.AlarmHistoryRepository;
+import com.moing.backend.global.annotation.DomainService;
+import lombok.RequiredArgsConstructor;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@DomainService
+@Transactional
+@RequiredArgsConstructor
+public class AlarmHistorySaveService {
+
+    private final AlarmHistoryRepository alarmHistoryRepository;
+
+    public void saveAlarmHistory(List<AlarmHistory> alarmHistories){
+        alarmHistoryRepository.saveAll(alarmHistories);
+    }
+
+}

--- a/src/main/java/com/moing/backend/domain/history/exception/AlarmHistoryException.java
+++ b/src/main/java/com/moing/backend/domain/history/exception/AlarmHistoryException.java
@@ -1,0 +1,11 @@
+package com.moing.backend.domain.history.exception;
+
+import com.moing.backend.global.exception.ApplicationException;
+import com.moing.backend.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public abstract class AlarmHistoryException extends ApplicationException {
+    protected AlarmHistoryException(ErrorCode errorCode, HttpStatus httpStatus) {
+        super(errorCode, httpStatus);
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/exception/NotFoundAlarmHistoryException.java
+++ b/src/main/java/com/moing/backend/domain/history/exception/NotFoundAlarmHistoryException.java
@@ -1,0 +1,11 @@
+package com.moing.backend.domain.history.exception;
+
+import com.moing.backend.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundAlarmHistoryException extends AlarmHistoryException {
+    public NotFoundAlarmHistoryException() {
+        super(ErrorCode.NOT_FOUND_BY_ALARM_HISOTRY_ID_ERROR,
+                HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moing/backend/domain/history/presentation/AlarmHistoryController.java
+++ b/src/main/java/com/moing/backend/domain/history/presentation/AlarmHistoryController.java
@@ -2,18 +2,18 @@ package com.moing.backend.domain.history.presentation;
 
 import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
 import com.moing.backend.domain.history.application.service.GetAlarmHistoryUseCase;
+import com.moing.backend.domain.history.application.service.ReadAlarmHistoryUseCase;
 import com.moing.backend.global.config.security.dto.User;
 import com.moing.backend.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 import static com.moing.backend.domain.history.presentation.constant.AlarmHistoryResponseMessage.GET_ALL_ALARM_HISTORY;
+import static com.moing.backend.domain.history.presentation.constant.AlarmHistoryResponseMessage.READ_ALARM_HISTORY;
 
 
 @RestController
@@ -22,7 +22,7 @@ import static com.moing.backend.domain.history.presentation.constant.AlarmHistor
 public class AlarmHistoryController {
 
     private final GetAlarmHistoryUseCase getAlarmHistoryUseCase;
-
+    private final ReadAlarmHistoryUseCase readAlarmHistoryUseCase;
     /**
      * 알림 전체 조회
      * [GET] api/history/alarm
@@ -33,6 +33,23 @@ public class AlarmHistoryController {
         return ResponseEntity.ok(SuccessResponse.create(GET_ALL_ALARM_HISTORY.getMessage(), getAlarmHistoryUseCase.getAllAlarmHistories(user.getSocialId())));
     }
 
-    //TODO: 알림 한개씩 읽기
+    /**
+     * 알림 한개 조회
+     * [POST] api/history/alarm/read?alarmHistoryId=1
+     */
+    @PostMapping("/read")
+    public ResponseEntity<SuccessResponse> readAlarmHistory(@AuthenticationPrincipal User user,
+                                                            @RequestParam Long alarmHistoryId) {
+        readAlarmHistoryUseCase.readAlarmHistory(user.getSocialId(), alarmHistoryId);
+        return ResponseEntity.ok(SuccessResponse.create(READ_ALARM_HISTORY.getMessage()));
+    }
 
+    /**
+     * 안 읽은 알림 개수 조회
+     * [GET] api/history/alarm/count
+     */
+    @GetMapping("/count")
+    public ResponseEntity<SuccessResponse<>> getAlarmHistoryCount(@AuthenticationPrincipal User user){
+        return ResponseEntity.ok(SuccessResponse.create())
+    }
 }

--- a/src/main/java/com/moing/backend/domain/history/presentation/AlarmHistoryController.java
+++ b/src/main/java/com/moing/backend/domain/history/presentation/AlarmHistoryController.java
@@ -1,0 +1,38 @@
+package com.moing.backend.domain.history.presentation;
+
+import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+import com.moing.backend.domain.history.application.service.GetAlarmHistoryUseCase;
+import com.moing.backend.global.config.security.dto.User;
+import com.moing.backend.global.response.SuccessResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.moing.backend.domain.history.presentation.constant.AlarmHistoryResponseMessage.GET_ALL_ALARM_HISTORY;
+
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/history/alarm")
+public class AlarmHistoryController {
+
+    private final GetAlarmHistoryUseCase getAlarmHistoryUseCase;
+
+    /**
+     * 알림 전체 조회
+     * [GET] api/history/alarm
+     * 작성자 : 김민수
+     */
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<GetAlarmHistoryResponse>>> getAllAlarmHistories(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(SuccessResponse.create(GET_ALL_ALARM_HISTORY.getMessage(), getAlarmHistoryUseCase.getAllAlarmHistories(user.getSocialId())));
+    }
+
+    //TODO: 알림 한개씩 읽기
+
+}

--- a/src/main/java/com/moing/backend/domain/history/presentation/AlarmHistoryController.java
+++ b/src/main/java/com/moing/backend/domain/history/presentation/AlarmHistoryController.java
@@ -44,12 +44,9 @@ public class AlarmHistoryController {
         return ResponseEntity.ok(SuccessResponse.create(READ_ALARM_HISTORY.getMessage()));
     }
 
+    //TODO
     /**
      * 안 읽은 알림 개수 조회
      * [GET] api/history/alarm/count
      */
-    @GetMapping("/count")
-    public ResponseEntity<SuccessResponse<>> getAlarmHistoryCount(@AuthenticationPrincipal User user){
-        return ResponseEntity.ok(SuccessResponse.create())
-    }
 }

--- a/src/main/java/com/moing/backend/domain/history/presentation/constant/AlarmHistoryResponseMessage.java
+++ b/src/main/java/com/moing/backend/domain/history/presentation/constant/AlarmHistoryResponseMessage.java
@@ -1,0 +1,12 @@
+package com.moing.backend.domain.history.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmHistoryResponseMessage {
+    GET_ALL_ALARM_HISTORY("알림 히스토리를 모두 조회했습니다."),
+    READ_ALARM_HISTORY("알림 히스토리 한 개를 조회했습니다.");
+    private final String message;
+}

--- a/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
@@ -7,7 +7,7 @@ import com.moing.backend.domain.member.domain.constant.Role;
 import com.moing.backend.domain.member.domain.constant.SocialProvider;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.moing.backend.global.entity.BaseTimeEntity;
-import com.moing.backend.global.util.AesConverter;
+import com.moing.backend.global.utils.AesConverter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateScheduleUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateScheduleUseCase.java
@@ -10,6 +10,7 @@ import com.moing.backend.domain.missionState.domain.service.MissionStateQuerySer
 import com.moing.backend.domain.teamScore.application.service.TeamScoreLogicUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ import java.util.List;
 @Slf4j
 @Service
 @Transactional
+@EnableAsync
 @EnableScheduling // 스케줄링 활성화
 @RequiredArgsConstructor
 public class MissionStateScheduleUseCase {

--- a/src/main/java/com/moing/backend/domain/team/domain/entity/Team.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/entity/Team.java
@@ -81,7 +81,9 @@ public class Team extends BaseTimeEntity {
 
     public void deleteTeam() {
         this.isDeleted=true;
-        this.deletionTime = LocalDateTime.now(ZoneId.of("Asia/Seoul")).withNano(0);
+        //TODO 테스트 용으로 현재 시간이 아닌 4일 전으로
+//        this.deletionTime = LocalDateTime.now().withNano(0);
+        this.deletionTime=LocalDateTime.now().minusDays(4).withNano(0);
     }
 
     public void addTeamMember(){

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
@@ -1,5 +1,6 @@
 package com.moing.backend.domain.teamMember.domain.repository;
 
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
@@ -9,6 +10,7 @@ import java.util.Optional;
 
 public interface TeamMemberCustomRepository {
     List<Long> findMemberIdsByTeamId(Long teamId);
+    Optional<List<MemberIdAndToken>> findIdAndTokensByTeamIdAndMemberId(Long teamId, Long memberId);
     Optional<List<String>> findFcmTokensByTeamIdAndMemberId(Long teamId, Long memberId);
     List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long teamId);
     List<TeamMember> findTeamMemberByMemberId(Long memberId);

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
@@ -1,10 +1,10 @@
 package com.moing.backend.domain.teamMember.domain.repository;
 
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
 import com.moing.backend.domain.team.application.dto.response.QTeamMemberInfo;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
-import com.moing.backend.domain.team.domain.constant.ApprovalStatus;
-import com.moing.backend.domain.team.domain.entity.QTeam;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
@@ -29,6 +29,21 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
                 .where(teamMember.team.teamId.eq(teamId)
                         .and(teamMember.team.isDeleted.eq(false)))
                 .fetch();
+    }
+
+    @Override
+    public Optional<List<MemberIdAndToken>> findIdAndTokensByTeamIdAndMemberId(Long teamId, Long memberId) {
+        List<MemberIdAndToken> result = queryFactory.select(Projections.constructor(MemberIdAndToken.class,
+                        teamMember.member.memberId,
+                        teamMember.member.fcmToken))
+                .from(teamMember)
+                .where(teamMember.team.teamId.eq(teamId)
+                        .and(teamMember.member.isNewUploadPush.eq(true))
+                        .and(teamMember.member.memberId.ne(memberId))
+                        .and(teamMember.isDeleted.eq(false)))
+                .fetch();
+
+        return result.isEmpty() ? Optional.empty() : Optional.of(result);
     }
 
     @Override

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
@@ -34,8 +34,8 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
     @Override
     public Optional<List<MemberIdAndToken>> findIdAndTokensByTeamIdAndMemberId(Long teamId, Long memberId) {
         List<MemberIdAndToken> result = queryFactory.select(Projections.constructor(MemberIdAndToken.class,
-                        teamMember.member.memberId,
-                        teamMember.member.fcmToken))
+                        teamMember.member.fcmToken,
+                        teamMember.member.memberId))
                 .from(teamMember)
                 .where(teamMember.team.teamId.eq(teamId)
                         .and(teamMember.member.isNewUploadPush.eq(true))

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
@@ -1,5 +1,6 @@
 package com.moing.backend.domain.teamMember.domain.service;
 
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
 import com.moing.backend.domain.team.domain.entity.Team;
@@ -35,5 +36,9 @@ public class TeamMemberGetService {
 
     public List<TeamMember> getNotDeletedTeamMember(Long memberId){
         return teamMemberRepository.findTeamMemberByMemberId(memberId);
+    }
+
+    public Optional<List<MemberIdAndToken>> getMemberInfoExceptMe(Long teamId, Long memberId) {
+        return teamMemberRepository.findIdAndTokensByTeamIdAndMemberId(teamId, memberId);
     }
 }

--- a/src/main/java/com/moing/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/moing/backend/global/response/ErrorCode.java
@@ -57,7 +57,10 @@ public enum ErrorCode {
 
     //게시글 댓글 관련 에러 코드
     NOT_FOUND_BY_BOARD_COMMENT_ID_ERROR("BC0001","해당 boardCommentId인 댓글이 존재하지 않습니다."),
-    NOT_AUTH_BY_BOARD_COMMENT_ID_ERROR("BC0002","권한이 없습니다.");
+    NOT_AUTH_BY_BOARD_COMMENT_ID_ERROR("BC0002","권한이 없습니다."),
+
+    //알림 관련 에러 코드
+    NOT_FOUND_BY_ALARM_HISOTRY_ID_ERROR("AH0001","해당 alarmHistoryId인 알림이 존재하지 않습니다.");
     private String errorCode;
     private String message;
 

--- a/src/main/java/com/moing/backend/global/utils/AesConverter.java
+++ b/src/main/java/com/moing/backend/global/utils/AesConverter.java
@@ -1,4 +1,4 @@
-package com.moing.backend.global.util;
+package com.moing.backend.global.utils;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;

--- a/src/main/java/com/moing/backend/global/utils/AesUtil.java
+++ b/src/main/java/com/moing/backend/global/utils/AesUtil.java
@@ -1,4 +1,4 @@
-package com.moing.backend.global.util;
+package com.moing.backend.global.utils;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/moing/backend/global/utils/BaseBoardService.java
+++ b/src/main/java/com/moing/backend/global/utils/BaseBoardService.java
@@ -1,4 +1,4 @@
-package com.moing.backend.global.util;
+package com.moing.backend.global.utils;
 
 import com.moing.backend.domain.board.domain.entity.Board;
 import com.moing.backend.domain.board.domain.service.BoardGetService;

--- a/src/main/java/com/moing/backend/global/utils/BaseService.java
+++ b/src/main/java/com/moing/backend/global/utils/BaseService.java
@@ -1,4 +1,4 @@
-package com.moing.backend.global.util;
+package com.moing.backend.global.utils;
 
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.member.domain.service.MemberGetService;

--- a/src/main/java/com/moing/backend/global/utils/FeignClientConfig.java
+++ b/src/main/java/com/moing/backend/global/utils/FeignClientConfig.java
@@ -1,4 +1,4 @@
-package com.moing.backend.global.util;
+package com.moing.backend.global.utils;
 
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/moing/backend/global/utils/SecurityUtils.java
+++ b/src/main/java/com/moing/backend/global/utils/SecurityUtils.java
@@ -1,4 +1,4 @@
-package com.moing.backend.global.util;
+package com.moing.backend.global.utils;
 
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.global.config.security.oauth.CustomUserDetails;

--- a/src/main/java/com/moing/backend/global/utils/StartupRunner.java
+++ b/src/main/java/com/moing/backend/global/utils/StartupRunner.java
@@ -1,11 +1,10 @@
-package com.moing.backend.global.util;
+package com.moing.backend.global.utils;
 
 import com.moing.backend.domain.member.domain.constant.Gender;
 import com.moing.backend.domain.member.domain.constant.RegistrationStatus;
 import com.moing.backend.domain.member.domain.constant.Role;
 import com.moing.backend.domain.member.domain.constant.SocialProvider;
 import com.moing.backend.domain.member.domain.entity.Member;
-import com.moing.backend.domain.member.domain.service.MemberGetService;
 import com.moing.backend.domain.member.domain.service.MemberSaveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;

--- a/src/test/java/com/moing/backend/domain/history/presentation/AlarmHistoryControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/history/presentation/AlarmHistoryControllerTest.java
@@ -1,31 +1,28 @@
 package com.moing.backend.domain.history.presentation;
 
 import com.moing.backend.config.CommonControllerTest;
-import com.moing.backend.domain.fire.application.dto.res.FireReceiveRes;
 import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
 import com.moing.backend.domain.history.application.service.GetAlarmHistoryUseCase;
+import com.moing.backend.domain.history.application.service.ReadAlarmHistoryUseCase;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.List;
 
-import static com.moing.backend.domain.fire.presentation.constant.FireResponseMessage.GET_RECEIVERS_SUCCESS;
 import static com.moing.backend.domain.history.presentation.constant.AlarmHistoryResponseMessage.GET_ALL_ALARM_HISTORY;
+import static com.moing.backend.domain.history.presentation.constant.AlarmHistoryResponseMessage.READ_ALARM_HISTORY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
@@ -34,6 +31,9 @@ class AlarmHistoryControllerTest extends CommonControllerTest {
 
     @MockBean
     private GetAlarmHistoryUseCase getAlarmHistoryUseCase;
+
+    @MockBean
+    private ReadAlarmHistoryUseCase readAlarmHistoryUseCase;
 
     @Test
     public void get_all_alarm_history() throws Exception {
@@ -86,4 +86,34 @@ class AlarmHistoryControllerTest extends CommonControllerTest {
                 .andReturn();
 
     }
+
+    @Test
+    public void read_alarm_history() throws Exception {
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                post("/api/history/alarm/read?alarmHistoryId=1")
+                        .header("Authorization", "Bearer ACCESS_TOKEN")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        actions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName("Authorization").description("접근 토큰")
+                                ),
+                                responseFields(
+                                        fieldWithPath("isSuccess").description("true"),
+                                        fieldWithPath("message").description(READ_ALARM_HISTORY.getMessage())
+
+                                )
+                        )
+                )
+                .andReturn();
+
+    }
+
 }

--- a/src/test/java/com/moing/backend/domain/history/presentation/AlarmHistoryControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/history/presentation/AlarmHistoryControllerTest.java
@@ -1,0 +1,89 @@
+package com.moing.backend.domain.history.presentation;
+
+import com.moing.backend.config.CommonControllerTest;
+import com.moing.backend.domain.fire.application.dto.res.FireReceiveRes;
+import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
+import com.moing.backend.domain.history.application.service.GetAlarmHistoryUseCase;
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static com.moing.backend.domain.fire.presentation.constant.FireResponseMessage.GET_RECEIVERS_SUCCESS;
+import static com.moing.backend.domain.history.presentation.constant.AlarmHistoryResponseMessage.GET_ALL_ALARM_HISTORY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@WebMvcTest(AlarmHistoryController.class)
+class AlarmHistoryControllerTest extends CommonControllerTest {
+
+    @MockBean
+    private GetAlarmHistoryUseCase getAlarmHistoryUseCase;
+
+    @Test
+    public void get_all_alarm_history() throws Exception {
+        //given
+        List<GetAlarmHistoryResponse> output = Lists.newArrayList(GetAlarmHistoryResponse.builder()
+                .alarmHistoryId(1L)
+                .type(AlarmType.NEW_UPLOAD)
+                .path("/post/detail")
+                .idInfo("{\"teamId\":74,\"boardId\":96}")
+                        .title("갓생살자에 새로 올라온 공지를 확인하세요!")
+                        .body("모임 장소 공지")
+                        .name("모닥모닥불")
+                        .isRead(false)
+                        .createdDate("오후 06:39")
+                .build());
+
+        given(getAlarmHistoryUseCase.getAllAlarmHistories(any())).willReturn(output);
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                get("/api/history/alarm")
+                        .header("Authorization", "Bearer ACCESS_TOKEN")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        actions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName("Authorization").description("접근 토큰")
+                                ),
+                                responseFields(
+                                        fieldWithPath("isSuccess").description("true"),
+                                        fieldWithPath("message").description(GET_ALL_ALARM_HISTORY.getMessage()),
+                                        fieldWithPath("data[].alarmHistoryId").description("알림 히스토리 아이디"),
+                                        fieldWithPath("data[].type").description("알림 아이콘 구분"),
+                                        fieldWithPath("data[].path").description("알림 이동 페이지 path"),
+                                        fieldWithPath("data[].idInfo").description("알림 페이지 이동할 때 필요한 data (JSON String)"),
+                                        fieldWithPath("data[].title").description("알림의 제목 (가장 bold 처리 된거)"),
+                                        fieldWithPath("data[].body").description("알림의 본문 (제목 밑)"),
+                                        fieldWithPath("data[].name").description("미션 리마인드 제외하고는 팀 이름 (제목 위)"),
+                                        fieldWithPath("data[].createdDate").description("작성 시간"),
+                                        fieldWithPath("data[].isRead").description("읽음여부")
+
+                                )
+                        )
+                )
+                .andReturn();
+
+    }
+}


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 알림 모아보기 기능 추가

## 변경 사항
1. 게시글 생성할 때 알림 히스토리 insert
https://github.com/Modagbul/MOING_Server_Release/blob/10295efaebab7d53344c28491f20980e07f47419/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java#L38-L87

2. 알림 전체 조회할 때 현재 사용자의 모든 알림 가져오기
https://github.com/Modagbul/MOING_Server_Release/blob/10295efaebab7d53344c28491f20980e07f47419/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepositoryImpl.java#L21-L35

## 코드 리뷰 시 참고 사항
1. AlarmHistory저장하는걸 인터페이스 이용해서 범용적으로 쓰게 만들고 싶었으나... 생각보다 각 케이스마다 다른 점이 너무 많아서 끝내 그 해결방안을 찾을 수 없었습니다... 좋은 의견이 있으시다면,,, 공유부탁드립니다.
-> 승연이가 말한대로 공통함수를 묶어서 해결했습니다 :) 
https://github.com/Modagbul/MOING_Server_Release/blob/74993015b025fabc0bae04a8ba72fe63b6b5e0d2/src/main/java/com/moing/backend/domain/history/application/service/SaveMultiAlarmHistoryUseCase.java#L15-L28

https://github.com/Modagbul/MOING_Server_Release/blob/74993015b025fabc0bae04a8ba72fe63b6b5e0d2/src/main/java/com/moing/backend/domain/history/application/service/SaveSingleAlarmHistoryUseCase.java#L11-L23

그래서 이렇게 코드가 깔끔해졌답니다 ~~
https://github.com/Modagbul/MOING_Server_Release/blob/74993015b025fabc0bae04a8ba72fe63b6b5e0d2/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java#L35-L58


2. 게시글 생성할 때 게시글 db저장/ 알림 보내기/ 알림 db저장 모두 처리되는데 이게 맞나? 라는 생각이 들면서 이렇게 해도 되나 고민이 들더라구요... 미션쪽도 그럴 거 같은데 어떻게 처리하고 있으신지 궁금합니다

3. 알림 읽음처리는 금방 끝낼 수 있을 것 같아 추후에 추가할 예정입니다. (전에 게시글 읽음처리라고 했는데 게시글 읽음 처리는 진작에 끝났었습니다 허허 ...)
-> 알림 읽음 (조회) 까지 했고 안 읽은 알림의 개수도 곧 할 예정입니닷 !

## 테스트 결과
https://github.com/Modagbul/MOING_Server_Release/blob/10295efaebab7d53344c28491f20980e07f47419/src/test/java/com/moing/backend/domain/history/presentation/AlarmHistoryControllerTest.java#L32-L88
