### PR TITLE
Feat/mission alarm

### DIFF
--- a/src/main/java/com/moing/backend/domain/fire/domain/repository/FireCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/fire/domain/repository/FireCustomRepositoryImpl.java
@@ -92,7 +92,8 @@ public class FireCustomRepositoryImpl implements FireCustomRepository {
                 .where(
                         teamMember.team.teamId.eq(teamId),
                         teamMember.member.memberId.ne(memberId),
-                        teamMember.member.memberId.notIn(missionDonePeople)
+                        teamMember.member.memberId.notIn(missionDonePeople),
+                        teamMember.member.isDeleted.ne(Boolean.TRUE)
                 )
                 .fetch());
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
@@ -251,12 +251,12 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
                 .where(
                         mission.team.teamId.eq(teamId),
                         mission.type.eq(MissionType.REPEAT),
-                        mission.status.eq(MissionStatus.ONGOING).or(mission.status.eq(MissionStatus.WAIT)),
+                        mission.status.eq(MissionStatus.ONGOING),
                         repeatTypeCondition
 
                 )
                 .groupBy(mission.id,mission.number)
-//                .having(missionState.count().lt(mission.number)) // HAVING 절을 사용하여 조건 적용
+                .having(missionState.count().lt(mission.number)) // HAVING 절을 사용하여 조건 적용
                 .orderBy(missionState.count().desc())
                 .fetch());
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,7 +25,10 @@ import org.springframework.data.jpa.repository.Query;
 
 import javax.persistence.EntityManager;
 import javax.swing.text.html.Option;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -117,13 +121,20 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
    @Override
     public Optional<List<MissionArchive>> findOneMyArchives(Long memberId,Long missionId,Long count) {
 
+
+       BooleanExpression repeatTypeCondition = createRepeatTypeConditionByArchive();
+       BooleanExpression baseCondition = missionArchive.mission.id.eq(missionId);
+       BooleanExpression finalCondition = baseCondition.and(repeatTypeCondition);
+
         return Optional.ofNullable(queryFactory
                 .select(missionArchive)
                  .from(missionArchive)
                  .where(
-                        missionArchive.mission.id.eq(missionId),
+                         finalCondition,
                         missionArchive.member.memberId.eq(memberId),
                          missionArchive.count.eq(count)
+
+
                 )
                 .orderBy(missionArchive.createdDate.desc())
                 .fetch()
@@ -134,11 +145,16 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
     @Override
     public Optional<List<MissionArchive>> findMyArchives(Long memberId,Long missionId) {
 
+
+        BooleanExpression repeatTypeCondition = createRepeatTypeConditionByArchive();
+        BooleanExpression baseCondition = missionArchive.mission.id.eq(missionId);
+        BooleanExpression finalCondition = baseCondition.and(repeatTypeCondition);
+
         return Optional.ofNullable(queryFactory
                 .select(missionArchive)
                  .from(missionArchive)
                  .where(
-                        missionArchive.mission.id.eq(missionId),
+                         finalCondition,
                         missionArchive.member.memberId.eq(memberId)
                 )
                 .orderBy(missionArchive.createdDate.desc())
@@ -151,11 +167,16 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
     @Override
     public Optional<List<MissionArchive>> findOthersArchives(Long memberId, Long missionId) {
 
+
+        BooleanExpression repeatTypeCondition = createRepeatTypeConditionByArchive();
+        BooleanExpression baseCondition = missionArchive.mission.id.eq(missionId);
+        BooleanExpression finalCondition = baseCondition.and(repeatTypeCondition);
+
         return Optional.ofNullable(queryFactory
                 .select(missionArchive)
                 .from(missionArchive)
                 .where(
-                        missionArchive.mission.id.eq(missionId),
+                        finalCondition,
                         missionArchive.member.memberId.ne(memberId),
                         missionArchive.status.eq(MissionArchiveStatus.COMPLETE).or(missionArchive.status.eq(MissionArchiveStatus.SKIP))
                 )
@@ -167,13 +188,19 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
 
     @Override
     public Optional<Long> findDonePeopleByMissionId(Long missionId) {
+
+        BooleanExpression repeatTypeCondition = createRepeatTypeCondition();
+        BooleanExpression baseCondition = missionState.mission.id.eq(missionId);
+        BooleanExpression finalCondition = baseCondition.and(repeatTypeCondition);
+
         return Optional.of(queryFactory
-                .select(missionArchive)
-                .from(missionArchive)
+                .select(missionState)
+                .from(missionState)
                 .where(
-                        missionArchive.mission.id.eq(missionId)
+                        finalCondition
                 )
-                .groupBy(missionArchive.member)
+                .groupBy(missionState.member,missionState.mission.number)
+                .having(missionState.count().goe(missionState.mission.number))
                 .fetchCount()
 
         );
@@ -181,12 +208,18 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
 
     @Override
     public Optional<Long> findMyDoneCountByMissionId(Long missionId, Long memberId) {
+
+
+        BooleanExpression repeatTypeCondition = createRepeatTypeCondition();
+        BooleanExpression baseCondition = missionState.mission.id.eq(missionId);
+        BooleanExpression finalCondition = baseCondition.and(repeatTypeCondition);
+
         return Optional.ofNullable(queryFactory
-                .select(missionArchive.count())
-                .from(missionArchive)
+                .select(missionState.count())
+                .from(missionState)
                 .where(
-                        missionArchive.mission.id.eq(missionId),
-                        missionArchive.member.memberId.eq(memberId)
+                        finalCondition,
+                        missionState.member.memberId.eq(memberId)
                 )
                 .fetchFirst()
         );
@@ -195,6 +228,11 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
 
     @Override
     public Optional<List<RepeatMissionBoardRes>> findRepeatMissionArchivesByMemberId(Long memberId, Long teamId, MissionStatus status) {
+
+
+        BooleanExpression repeatTypeCondition = createRepeatTypeCondition();
+
+
         return Optional.ofNullable(queryFactory
                 .select(Projections.constructor(RepeatMissionBoardRes.class,
                                 mission.id,
@@ -213,10 +251,12 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
                 .where(
                         mission.team.teamId.eq(teamId),
                         mission.type.eq(MissionType.REPEAT),
-                        mission.status.eq(MissionStatus.ONGOING).or(mission.status.eq(MissionStatus.WAIT))
+                        mission.status.eq(MissionStatus.ONGOING).or(mission.status.eq(MissionStatus.WAIT)),
+                        repeatTypeCondition
+
                 )
                 .groupBy(mission.id,mission.number)
-                .having(missionState.count().lt(mission.number)) // HAVING 절을 사용하여 조건 적용
+//                .having(missionState.count().lt(mission.number)) // HAVING 절을 사용하여 조건 적용
                 .orderBy(missionState.count().desc())
                 .fetch());
 
@@ -230,19 +270,22 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
         Expression<String> type = Expressions.stringTemplate(String.valueOf(mission.type));
 
 
+        BooleanExpression repeatTypeCondition = createRepeatTypeCondition();
+
         return Optional.ofNullable(queryFactory
                 .selectDistinct(Projections.constructor(FinishMissionBoardRes.class,
                     mission.id,
                     mission.dueTo.stringValue(),
                     mission.title,
-                    missionArchive.status.stringValue().coalesce("FAIL").as("status"),
+                    missionState.status.stringValue().coalesce("FAIL").as("status"),
                     mission.type.stringValue(),
                         mission.way.stringValue()
                 ))
                 .from(mission)
                 .leftJoin(mission.missionArchiveList,missionArchive)
-                        .on(missionArchive.member.memberId.eq(memberId))
+                        .on(missionState.member.memberId.eq(memberId))
                 .where(
+                        repeatTypeCondition,
                         mission.team.teamId.eq(teamId),
                         mission.status.eq(MissionStatus.SUCCESS).or(mission.status.eq(MissionStatus.END))
                 )
@@ -293,11 +336,11 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
         LocalDateTime endOfToday = today.withHour(23).withMinute(59).withSecond(59).withNano(999999999);
 
         long count = queryFactory
-                .selectFrom(missionArchive)
+                .selectFrom(missionState)
                 .where(
-                        missionArchive.member.memberId.eq(memberId),
-                        missionArchive.mission.id.eq(missionId),
-                        missionArchive.lastModifiedDate.between(startOfToday, endOfToday) // createdDate와 오늘의 시작과 끝을 비교
+                        missionState.member.memberId.eq(memberId),
+                        missionState.mission.id.eq(missionId),
+                        missionState.lastModifiedDate.between(startOfToday, endOfToday) // createdDate와 오늘의 시작과 끝을 비교
                 )
                 .fetchCount();
 
@@ -323,6 +366,38 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
 
 
 //                ).fetch());
+    }
+
+    // 날짜 조건 생성 메서드
+    private BooleanExpression createRepeatTypeCondition() {
+        LocalDate now = LocalDate.now();
+        DayOfWeek firstDayOfWeek = DayOfWeek.MONDAY;
+        LocalDate startOfWeek = now.with(TemporalAdjusters.previousOrSame(firstDayOfWeek));
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+
+        // MissionType.REPEAT 인 경우의 추가적인 날짜 범위 조건
+        BooleanExpression isRepeatType = missionState.mission.type.eq(MissionType.REPEAT);
+        BooleanExpression dateInRange = missionState.createdDate.goe(startOfWeek.atStartOfDay())
+                .and(missionState.createdDate.loe(endOfWeek.atStartOfDay().plusDays(1).minusNanos(1)));
+
+        // 조건이 MissionType.REPEAT 인 경우에만 날짜 범위 조건 적용
+        return isRepeatType.and(dateInRange);
+    }
+
+    // 날짜 조건 생성 메서드
+    private BooleanExpression createRepeatTypeConditionByArchive() {
+        LocalDate now = LocalDate.now();
+        DayOfWeek firstDayOfWeek = DayOfWeek.MONDAY;
+        LocalDate startOfWeek = now.with(TemporalAdjusters.previousOrSame(firstDayOfWeek));
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+
+        // MissionType.REPEAT 인 경우의 추가적인 날짜 범위 조건
+        BooleanExpression isRepeatType = missionArchive.mission.type.eq(MissionType.REPEAT);
+        BooleanExpression dateInRange = missionArchive.createdDate.goe(startOfWeek.atStartOfDay())
+                .and(missionArchive.createdDate.loe(endOfWeek.atStartOfDay().plusDays(1).minusNanos(1)));
+
+        // 조건이 MissionType.REPEAT 인 경우에만 날짜 범위 조건 적용
+        return isRepeatType.and(dateInRange);
     }
 
 

--- a/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateScheduleUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateScheduleUseCase.java
@@ -50,31 +50,8 @@ public class MissionStateScheduleUseCase {
         for (Long id : ongoingRepeatMissions) {
             teamScoreLogicUseCase.updateTeamScore(id);
         }
-        // 미션 state 에서 지우기 ( 이것도 대용량 )
-        missionStateReset(ongoingRepeatMissions);
     }
 
-    public void missionStateReset(List<Long> missionIds) {
-        List<MissionState> missionStates = missionStateQueryService.findByMissionId(missionIds);
-        missionStateDeleteService.deleteMissionState(missionStates);
-    }
-
-
-//    /**
-//     * 단일 미션 마감
-//     * 미션 단위 마감
-//     * 한시간 마다 실행
-//     */
-//    public void singleMissionEndRoutineByMission() {
-//
-//        Mission mission = new Mission();
-//        LocalDateTime now = LocalDateTime.now();
-//
-//        if (mission.getDueTo().isAfter(now)) {
-//            mission.updateStatus(MissionStatus.END);
-//            teamScoreLogicUseCase.updateTeamScore(mission.getId());
-//        }
-//    }
 
     /**
      * 단일 미션 마감
@@ -94,7 +71,6 @@ public class MissionStateScheduleUseCase {
 
     }
 
-
     /**
      * 미션 시작
      * 월요일 아침
@@ -102,7 +78,7 @@ public class MissionStateScheduleUseCase {
     @Scheduled(cron = "0 0 0 * * MON")
     public void RepeatMissionStart() {
         List<Mission> startMission = missionQueryService.findMissionByStatus(MissionStatus.WAIT);
-        startMission.stream().forEach(
+        startMission.forEach(
             mission -> mission.updateStatus(MissionStatus.ONGOING)
         );
     }

--- a/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateUseCase.java
@@ -79,25 +79,7 @@ public class MissionStateUseCase {
             teamScoreLogicUseCase.updateTeamScore(mission.getId());
         }
 
-
     }
-
-    public void deleteMissionState(Member member, Mission mission, MissionArchive missionArchive) {
-
-        MissionState missionState = missionStateQueryService.findMissionState(member, mission);
-        missionStateDeleteService.deleteMissionState(missionState);
-
-    }
-
-    public void missionStateReset(List<Long> missionIds) {
-        List<MissionState> missionStates = missionStateQueryService.findByMissionId(missionIds);
-        missionStateDeleteService.deleteMissionState(missionStates);
-    }
-
-    public void deleteAllMissionState(Long missionId) {
-        missionStateDeleteService.deleteMissionStateByMission(missionId);
-    }
-
 
 
 }

--- a/src/main/java/com/moing/backend/domain/missionState/domain/repository/MissionStateCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionState/domain/repository/MissionStateCustomRepositoryImpl.java
@@ -10,7 +10,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import javax.persistence.EntityManager;
 
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,11 +30,19 @@ public class MissionStateCustomRepositoryImpl implements MissionStateCustomRepos
 
     @Override
     public int getCountsByMissionId(Long missionId) {
+
+        LocalDate now = LocalDate.now();
+        DayOfWeek firstDayOfWeek = DayOfWeek.MONDAY; // 한 주의 시작일을 월요일로 설정
+        LocalDate startOfWeek = now.with(TemporalAdjusters.previousOrSame(firstDayOfWeek));
+        LocalDate endOfWeek = startOfWeek.plusDays(6); // 한 주의 마지막일을 일요일로 설정
+
         return queryFactory
                 .select(missionState)
                 .from(missionState)
                 .where(
-                        missionState.mission.id.eq(missionId))
+                        missionState.mission.id.eq(missionId),
+                        missionState.createdDate.goe(startOfWeek.atStartOfDay()),
+                        missionState.createdDate.loe(endOfWeek.atStartOfDay().plusDays(1).minusNanos(1)))
                 .fetch().size();
     }
 

--- a/src/main/java/com/moing/backend/domain/missionState/domain/repository/MissionStateCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionState/domain/repository/MissionStateCustomRepositoryImpl.java
@@ -3,8 +3,10 @@ package com.moing.backend.domain.missionState.domain.repository;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionStatus;
+import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchiveStatus;
 import com.moing.backend.domain.missionState.domain.entity.MissionState;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
@@ -36,13 +38,20 @@ public class MissionStateCustomRepositoryImpl implements MissionStateCustomRepos
         LocalDate startOfWeek = now.with(TemporalAdjusters.previousOrSame(firstDayOfWeek));
         LocalDate endOfWeek = startOfWeek.plusDays(6); // 한 주의 마지막일을 일요일로 설정
 
+        BooleanExpression repeatTypeCondition = missionState.mission.type.eq(MissionType.REPEAT)
+                .and(missionState.createdDate.goe(startOfWeek.atStartOfDay()))
+                .and(missionState.createdDate.loe(endOfWeek.atStartOfDay().plusDays(1).minusNanos(1)));
+
+        // 기본 조건
+        BooleanExpression baseCondition = missionState.mission.id.eq(missionId);
+        // 조건 적용
+        BooleanExpression finalCondition = baseCondition.and(repeatTypeCondition);
+
+
         return queryFactory
                 .select(missionState)
                 .from(missionState)
-                .where(
-                        missionState.mission.id.eq(missionId),
-                        missionState.createdDate.goe(startOfWeek.atStartOfDay()),
-                        missionState.createdDate.loe(endOfWeek.atStartOfDay().plusDays(1).minusNanos(1)))
+                .where(finalCondition)
                 .fetch().size();
     }
 

--- a/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreLogicUseCase.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreLogicUseCase.java
@@ -46,7 +46,6 @@ public class TeamScoreLogicUseCase {
 
         teamScore.updateScore(getScoreByMission(mission));
         teamScore.levelUp();
-        team.updateLevelOfFire();
 
         teamScoreSaveService.save(teamScore);
         teamSaveService.saveTeam(team);

--- a/src/main/java/com/moing/backend/domain/teamScore/domain/entity/TeamScore.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/domain/entity/TeamScore.java
@@ -42,9 +42,10 @@ public class TeamScore extends BaseTimeEntity {
 
         for (int i = 5; i > 0; i--) {
             if (steps[i-1] <= this.level && this.level <= steps[i]) {
-                if (20 + ((i-1) * 15) <= score) {
+                if ((20 + ((i-1) * 15)) <= score) {
                     this.level+=1;
                     this.score -= (20 + ((i-1) * 15));
+                    this.team.updateLevelOfFire();
                     return;
                 }
             }

--- a/src/test/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImplTest.java
+++ b/src/test/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImplTest.java
@@ -12,6 +12,7 @@
 //import static com.moing.backend.domain.mission.domain.entity.QMission.mission;
 //import static com.moing.backend.domain.missionState.domain.entity.QMissionState.missionState;
 //@SpringBootTest
+//
 //class MissionArchiveCustomRepositoryImplTest {
 //
 //    @Autowired


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
[fix : 반복미션 마감 로직 수정 ( missionState 삭제 로직 삭제 )](https://github.com/Modagbul/MOING_Server_Release/commit/5ce05a0fddf6cd20cfbddd87cae32954abc05f21)
[fix : 반복미션 마감 로직 위해 missionArchive -> missionState](https://github.com/Modagbul/MOING_Server_Release/commit/158420d64b8df88f23c2012cd122907584b518bb)
[fix : 탈퇴한 소모임원 불던지기 리스트에서 삭제](https://github.com/Modagbul/MOING_Server_Release/commit/568b4900b7ae65f74cd923d81e84ac2e79f56674)
[fix : 진행중미션 보드 반복미션 관련 로직 -> 인증 완료한 미션 뜨지 않게, 진행 예정 미션 뜨지 않게](https://github.com/Modagbul/MOING_Server_Release/commit/3c5861449aff9910c67d6e251b391f10514b439a)

## 변경 사항

## 코드 리뷰 시 참고 사항

## 테스트 결과
