### PR TITLE
refactor: 알림보낼 때 로그아웃, 알림 여부 쿼리가 아닌 mapper로 수정

### DIFF
--- a/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/board/application/service/SendBoardAlarmUseCase.java
@@ -2,6 +2,8 @@ package com.moing.backend.domain.board.application.service;
 
 import com.moing.backend.domain.board.domain.entity.Board;
 import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
 import com.moing.backend.domain.history.domain.entity.PagePath;
 import com.moing.backend.domain.member.domain.entity.Member;
@@ -35,8 +37,9 @@ public class SendBoardAlarmUseCase {
         if (board.isNotice()) {
             String title = NEW_NOTICE_UPLOAD_MESSAGE.title(team.getName());
             String body = NEW_NOTICE_UPLOAD_MESSAGE.body(board.getTitle());
-            Optional<List<MemberIdAndToken>> memberIdAndTokensByPush = teamMemberGetService.getNewUploadPushInfo(team.getTeamId(), member.getMemberId());
-            Optional<List<MemberIdAndToken>> memberIdAndTokensBySave = teamMemberGetService.getNewUploadSaveInfo(team.getTeamId(), member.getMemberId());
+            Optional<List<NewUploadInfo>> newUploadInfos=teamMemberGetService.getNewUploadInfo(team.getTeamId(), member.getMemberId());
+            Optional<List<MemberIdAndToken>> memberIdAndTokensByPush = AlarmHistoryMapper.getNewUploadPushInfo(newUploadInfos);
+            Optional<List<MemberIdAndToken>> memberIdAndTokensBySave = AlarmHistoryMapper.getNewUploadSaveInfo(newUploadInfos);
             // 알림 보내기
             eventPublisher.publishEvent(new MultiFcmEvent(title, body, memberIdAndTokensByPush, memberIdAndTokensBySave, createIdInfo(team.getTeamId(), board.getBoardId()), team.getName(), AlarmType.NEW_UPLOAD, PagePath.NOTICE_PATH.getValue()));
         }

--- a/src/main/java/com/moing/backend/domain/history/application/dto/response/NewUploadInfo.java
+++ b/src/main/java/com/moing/backend/domain/history/application/dto/response/NewUploadInfo.java
@@ -1,0 +1,19 @@
+package com.moing.backend.domain.history.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NewUploadInfo {
+
+    private String fcmToken;
+    private Long memberId;
+    private boolean isNewUploadPush;
+    private boolean isSignOut;
+
+}

--- a/src/main/java/com/moing/backend/domain/history/application/mapper/AlarmHistoryMapper.java
+++ b/src/main/java/com/moing/backend/domain/history/application/mapper/AlarmHistoryMapper.java
@@ -1,6 +1,7 @@
 package com.moing.backend.domain.history.application.mapper;
 
 import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.history.domain.entity.AlarmHistory;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -52,6 +54,24 @@ public class AlarmHistoryMapper {
         return memberIds.stream()
                 .map(memberId -> toAlarmHistory(alarmType, path, idInfo, memberId, title, body, teamName))
                 .collect(Collectors.toList());
+    }
+
+    public static Optional<List<MemberIdAndToken>> getNewUploadSaveInfo(Optional<List<NewUploadInfo>> optionalNewUploadInfos) {
+        return optionalNewUploadInfos.map(newUploadInfos ->
+                newUploadInfos.stream()
+                        .map(info -> new MemberIdAndToken(info.getFcmToken(), info.getMemberId()))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public static Optional<List<MemberIdAndToken>> getNewUploadPushInfo(Optional<List<NewUploadInfo>> optionalNewUploadInfos) {
+        return optionalNewUploadInfos.map(newUploadInfos ->
+                newUploadInfos.stream()
+                        .filter(NewUploadInfo::isNewUploadPush)
+                        .filter(info -> !info.isSignOut())
+                        .map(info -> new MemberIdAndToken(info.getFcmToken(), info.getMemberId()))
+                        .collect(Collectors.toList())
+        );
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/mission/application/service/SendMissionCreateAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/mission/application/service/SendMissionCreateAlarmUseCase.java
@@ -1,6 +1,8 @@
 package com.moing.backend.domain.mission.application.service;
 
 import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
 import com.moing.backend.domain.history.domain.entity.PagePath;
 import com.moing.backend.domain.member.domain.entity.Member;
@@ -36,8 +38,10 @@ public class SendMissionCreateAlarmUseCase {
         String type = mission.getType().toString();
         String status = mission.getStatus().toString();
 
-        Optional<List<MemberIdAndToken>> memberIdAndTokensByPush = teamMemberGetService.getNewUploadPushInfo(team.getTeamId(), member.getMemberId());
-        Optional<List<MemberIdAndToken>> memberIdAndTokensBySave = teamMemberGetService.getNewUploadSaveInfo(team.getTeamId(), member.getMemberId());
+        Optional<List<NewUploadInfo>> newUploadInfos=teamMemberGetService.getNewUploadInfo(team.getTeamId(), member.getMemberId());
+
+        Optional<List<MemberIdAndToken>> memberIdAndTokensByPush = AlarmHistoryMapper.getNewUploadPushInfo(newUploadInfos);
+        Optional<List<MemberIdAndToken>> memberIdAndTokensBySave = AlarmHistoryMapper.getNewUploadSaveInfo(newUploadInfos);
         // 알림 보내기
         eventPublisher.publishEvent(new MultiFcmEvent(title, message, memberIdAndTokensByPush, memberIdAndTokensBySave, createIdInfo(team.getTeamId(), mission.getId(),mission.getType(),mission.getStatus()), team.getName(), AlarmType.NEW_UPLOAD, PagePath.MISSION_PATH.getValue()));
     }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
@@ -1,6 +1,7 @@
 package com.moing.backend.domain.teamMember.domain.repository;
 
 import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
@@ -10,10 +11,7 @@ import java.util.Optional;
 
 public interface TeamMemberCustomRepository {
     List<Long> findMemberIdsByTeamId(Long teamId);
-    Optional<List<MemberIdAndToken>> findNewUploadPushInfo(Long teamId, Long memberId);
-    Optional<List<MemberIdAndToken>> findNewUploadSaveInfo(Long teamId, Long memberId);
-    Optional<List<MemberIdAndToken>> findRemindPushInfo(Long teamId, Long memberId);
-    Optional<List<MemberIdAndToken>> findRemindSaveInfo(Long teamId, Long memberId);
+    Optional<List<NewUploadInfo>> findNewUploadInfo(Long teamId, Long memberId);
     Optional<List<String>> findFcmTokensByTeamIdAndMemberId(Long teamId, Long memberId);
     List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long teamId);
     List<TeamMember> findTeamMemberByMemberId(Long memberId);

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.moing.backend.domain.teamMember.domain.repository;
 
 import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.team.application.dto.response.QTeamMemberInfo;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
@@ -32,55 +33,12 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
     }
 
     @Override
-    public Optional<List<MemberIdAndToken>> findNewUploadPushInfo(Long teamId, Long memberId) {
-        List<MemberIdAndToken> result = queryFactory.select(Projections.constructor(MemberIdAndToken.class,
+    public Optional<List<NewUploadInfo>> findNewUploadInfo(Long teamId, Long memberId) {
+        List<NewUploadInfo> result = queryFactory.select(Projections.constructor(NewUploadInfo.class,
                         teamMember.member.fcmToken,
-                        teamMember.member.memberId))
-                .from(teamMember)
-                .where(teamMember.team.teamId.eq(teamId)
-                        .and(teamMember.member.isNewUploadPush.eq(true))
-                        .and(teamMember.member.isSignOut.eq(false))
-                        .and(teamMember.member.memberId.ne(memberId))
-                        .and(teamMember.isDeleted.eq(false)))
-                .fetch();
-
-        return result.isEmpty() ? Optional.empty() : Optional.of(result);
-    }
-
-    @Override
-    public Optional<List<MemberIdAndToken>> findNewUploadSaveInfo(Long teamId, Long memberId) {
-        List<MemberIdAndToken> result = queryFactory.select(Projections.constructor(MemberIdAndToken.class,
-                        teamMember.member.fcmToken,
-                        teamMember.member.memberId))
-                .from(teamMember)
-                .where(teamMember.team.teamId.eq(teamId)
-                        .and(teamMember.member.memberId.ne(memberId))
-                        .and(teamMember.isDeleted.eq(false)))
-                .fetch();
-
-        return result.isEmpty() ? Optional.empty() : Optional.of(result);
-    }
-    @Override
-    public Optional<List<MemberIdAndToken>> findRemindPushInfo(Long teamId, Long memberId) {
-        List<MemberIdAndToken> result = queryFactory.select(Projections.constructor(MemberIdAndToken.class,
-                        teamMember.member.fcmToken,
-                        teamMember.member.memberId))
-                .from(teamMember)
-                .where(teamMember.team.teamId.eq(teamId)
-                        .and(teamMember.member.isRemindPush.eq(true))
-                        .and(teamMember.member.isSignOut.eq(false))
-                        .and(teamMember.member.memberId.ne(memberId))
-                        .and(teamMember.isDeleted.eq(false)))
-                .fetch();
-
-        return result.isEmpty() ? Optional.empty() : Optional.of(result);
-    }
-
-    @Override
-    public Optional<List<MemberIdAndToken>> findRemindSaveInfo(Long teamId, Long memberId) {
-        List<MemberIdAndToken> result = queryFactory.select(Projections.constructor(MemberIdAndToken.class,
-                        teamMember.member.fcmToken,
-                        teamMember.member.memberId))
+                        teamMember.member.memberId,
+                        teamMember.member.isNewUploadPush,
+                        teamMember.member.isSignOut))
                 .from(teamMember)
                 .where(teamMember.team.teamId.eq(teamId)
                         .and(teamMember.member.memberId.ne(memberId))

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
@@ -1,6 +1,7 @@
 package com.moing.backend.domain.teamMember.domain.service;
 
 import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
 import com.moing.backend.domain.team.domain.entity.Team;
@@ -38,20 +39,9 @@ public class TeamMemberGetService {
         return teamMemberRepository.findTeamMemberByMemberId(memberId);
     }
 
-    public Optional<List<MemberIdAndToken>> getNewUploadPushInfo(Long teamId, Long memberId) {
-        return teamMemberRepository.findNewUploadPushInfo(teamId, memberId);
+    public Optional<List<NewUploadInfo>> getNewUploadInfo(Long teamId, Long memberId) {
+        return teamMemberRepository.findNewUploadInfo(teamId, memberId);
     }
 
-    public Optional<List<MemberIdAndToken>> getNewUploadSaveInfo(Long teamId, Long memberId) {
-        return teamMemberRepository.findNewUploadSaveInfo(teamId, memberId);
-    }
-
-    public Optional<List<MemberIdAndToken>> getRemindPushInfo(Long teamId, Long memberId) {
-        return teamMemberRepository.findRemindPushInfo(teamId, memberId);
-    }
-
-    public Optional<List<MemberIdAndToken>> getRemindSaveInfo(Long teamId, Long memberId) {
-        return teamMemberRepository.findRemindSaveInfo(teamId, memberId);
-    }
 
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요

## 변경 사항
- 알림보낼 때 로그아웃, 알림 여부를 쿼리가 아닌 mapper로 수정
