### PR TITLE
fix : 반복미션 종료 로직 버그 수정

### DIFF
--- a/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionState/application/service/MissionStateUseCase.java
@@ -42,7 +42,7 @@ public class MissionStateUseCase {
         Long total = totalPeople(mission);
         Long done = donePeople(mission);
 
-        return done.equals(total);
+        return done >= total;
 
     }
     public boolean isAbleToScoreUp(Long missionId) {
@@ -70,7 +70,7 @@ public class MissionStateUseCase {
     public void updateMissionState(Member member, Mission mission, MissionArchive missionArchive) {
 
         // 마지막 인증 시
-        if (isAbleToEnd(mission.getId())) {
+        if (mission.getType().equals(MissionType.ONCE) && isAbleToEnd(mission.getId())) {
             mission.updateStatus(MissionStatus.SUCCESS);
         }
         missionStateSaveService.saveMissionState(member,mission, missionArchive.getStatus());


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 반복미션 횟수를 모두 채웠을 시 반복미션이 종료되는 버그를 해결했습니다.
- 종료 가능 여부 확인 로직에서 done.equal(total) -> done >= total 로 변경하였습니다.

## 변경 사항

## 코드 리뷰 시 참고 사항

## 테스트 결과
