### PR TITLE
동시성 제어 해결

### DIFF
--- a/src/main/java/com/moing/backend/domain/boardRead/domain/repository/BoardReadRepository.java
+++ b/src/main/java/com/moing/backend/domain/boardRead/domain/repository/BoardReadRepository.java
@@ -5,10 +5,14 @@ import com.moing.backend.domain.boardRead.domain.entity.BoardRead;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.domain.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
+import javax.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 
 public interface BoardReadRepository extends JpaRepository<BoardRead, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<BoardRead> findBoardReadByBoardAndMemberAndTeam(Board board, Member member, Team team);
 }

--- a/src/main/java/com/moing/backend/domain/boardRead/domain/service/BoardReadSaveService.java
+++ b/src/main/java/com/moing/backend/domain/boardRead/domain/service/BoardReadSaveService.java
@@ -16,16 +16,15 @@ public class BoardReadSaveService {
 
     private final BoardReadRepository boardReadRepository;
 
-    public void saveBoardRead(Board board, BoardRead boardRead) {
-        List<BoardRead> existingBoardReads = boardReadRepository.findBoardReadByBoardAndMemberAndTeam(board, boardRead.getMember(), boardRead.getTeam());
 
-        if (existingBoardReads.size() > 1) {
-            // 첫 번째 엔티티를 제외하고 나머지 삭제
-            List<BoardRead> duplicates = existingBoardReads.subList(1, existingBoardReads.size());
-            boardReadRepository.deleteAll(duplicates);
-        } else if (existingBoardReads.isEmpty()) {
-            boardRead.updateBoard(board);
-            boardReadRepository.save(boardRead);
+    public void saveBoardRead(Board board, BoardRead boardRead) {
+        synchronized (this) {
+            List<BoardRead> existingBoardReads = boardReadRepository.findBoardReadByBoardAndMemberAndTeam(board, boardRead.getMember(), boardRead.getTeam());
+
+            if (existingBoardReads.isEmpty()) {
+                boardRead.updateBoard(board);
+                boardReadRepository.save(boardRead);
+            }
         }
     }
 }

--- a/src/main/java/com/moing/backend/domain/statistics/application/service/DAUScheduleUseCase.java
+++ b/src/main/java/com/moing/backend/domain/statistics/application/service/DAUScheduleUseCase.java
@@ -35,7 +35,7 @@ public class DAUScheduleUseCase {
     /*
     DAU 정보 : 일일 모임 생성 수, 일일 신규 가입자 수, 일일 반복 미션 생성 수, 일일 한번 미션 생성 수
      */
-    @Scheduled(cron = "0 59 23 * * *")
+    @Scheduled(cron = "0 55 23 * * *")
     public void DailyTeamCreationInfoAlarm() {
         Map<String, Long> todayStats = new LinkedHashMap<>();
         Map<String, Long> yesterdayStats = new LinkedHashMap<>();

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberRepository.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberRepository.java
@@ -4,13 +4,16 @@ import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import javax.persistence.LockModeType;
 import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long>, TeamMemberCustomRepository{
-    Optional<TeamMember> findTeamMemberByTeamAndMember(Team team, Member member);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<TeamMember> findTeamMemberByTeamAndMember(Team team, Member member);
 }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberSaveService.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberSaveService.java
@@ -19,14 +19,14 @@ import java.util.Optional;
 public class TeamMemberSaveService {
     private final TeamMemberRepository teamMemberRepository;
     public void addTeamMember(Team team, Member member) {
-        Optional<TeamMember> teamMember = teamMemberRepository.findTeamMemberByTeamAndMember(team, member);
-
-        checkDeletion(team);
-
-        if (teamMember.isPresent()) {
-            handleExistingMember(teamMember.get());
-        } else {
-            addNewTeamMember(team, member);
+        synchronized (this) {
+            Optional<TeamMember> teamMember = teamMemberRepository.findTeamMemberByTeamAndMember(team, member);
+            checkDeletion(team);
+            if (teamMember.isPresent()) {
+                handleExistingMember(teamMember.get());
+            } else {
+                addNewTeamMember(team, member);
+            }
         }
     }
 

--- a/src/main/java/com/moing/backend/global/config/slack/exception/ExceptionEventHandler.java
+++ b/src/main/java/com/moing/backend/global/config/slack/exception/ExceptionEventHandler.java
@@ -3,12 +3,14 @@ package com.moing.backend.global.config.slack.exception;
 import com.moing.backend.global.config.slack.exception.dto.ExceptionEvent;
 import com.moing.backend.global.config.slack.util.WebhookUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
+@Profile("prod")
 public class ExceptionEventHandler {
 
     private final WebhookUtil webhookUtil;


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
1. teamMember, boardRead를 저장할 때 연속으로 insert되는 문제 해결
2. 슬랙 알림 (에러 관련)이 운영 서버에 관해서만 가게 수정

## 변경 사항
1. teamMember, boardRead를 저장할 때 연속으로 insert되는 문제 해결
-> 로직에는 중복 제거를 넣었는데, 동시성 문제 때문에 연속으로 같은 값이 insert됨 (락을 이용해 해결)

2. 슬랙 알림 (에러 관련)이 운영 서버에 관해서만 가게 수정
-> 로컬 서버에 관한 500에러는 슬랙 알림이 안가게 수정