### PR TITLE
MNG-05 모임 만들 때 카테고리 직접 입력할 수 있게 category enum 제거

### DIFF
--- a/src/main/java/com/moing/backend/domain/auth/application/dto/request/SignUpRequest.java
+++ b/src/main/java/com/moing/backend/domain/auth/application/dto/request/SignUpRequest.java
@@ -1,13 +1,12 @@
 package com.moing.backend.domain.auth.application.dto.request;
 
 import com.moing.backend.domain.member.domain.constant.Gender;
-import com.moing.backend.domain.team.domain.constant.Category;
-import com.moing.backend.global.annotation.Enum;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Builder

--- a/src/main/java/com/moing/backend/domain/mission/application/service/MissionCreateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/mission/application/service/MissionCreateUseCase.java
@@ -64,7 +64,7 @@ public class MissionCreateUseCase {
         Team team = teamGetService.getTeamByTeamId(teamId);
 
         return MissionRecommendRes.builder()
-                .category(team.getCategory().name())
+                .category(team.getCategory())
                 .build();
     }
 

--- a/src/main/java/com/moing/backend/domain/mission/application/service/MissionReadUseCase.java
+++ b/src/main/java/com/moing/backend/domain/mission/application/service/MissionReadUseCase.java
@@ -28,7 +28,7 @@ public class MissionReadUseCase {
 
     public String getTeamCategory(Long teamId) {
         Team team = teamGetService.getTeamByTeamId(teamId);
-        return team.getCategory().name();
+        return team.getCategory();
     }
 
 }

--- a/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageResponse.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageResponse.java
@@ -1,7 +1,5 @@
 package com.moing.backend.domain.mypage.application.dto.response;
 
-import com.moing.backend.domain.member.domain.entity.Member;
-import com.moing.backend.domain.team.domain.constant.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +16,6 @@ public class GetMyPageResponse {
     private String profileImage;
     private String nickName;
     private String introduction;
-    private List<Category> categories=new ArrayList<>();
+    private List<String> categories=new ArrayList<>();
     private List<GetMyPageTeamBlock> getMyPageTeamBlocks = new ArrayList<>();
 }

--- a/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageTeamBlock.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/dto/response/GetMyPageTeamBlock.java
@@ -1,7 +1,9 @@
 package com.moing.backend.domain.mypage.application.dto.response;
 
-import com.moing.backend.domain.team.domain.constant.Category;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor
@@ -10,6 +12,6 @@ import lombok.*;
 public class GetMyPageTeamBlock {
     private Long teamId;
     private String teamName;
-    private Category category;
+    private String category;
     private String profileImgUrl;
 }

--- a/src/main/java/com/moing/backend/domain/mypage/application/mapper/MyPageMapper.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/mapper/MyPageMapper.java
@@ -3,7 +3,6 @@ package com.moing.backend.domain.mypage.application.mapper;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.mypage.application.dto.response.GetMyPageResponse;
 import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
-import com.moing.backend.domain.team.domain.constant.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +12,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MyPageMapper {
 
-    public static GetMyPageResponse toGetMyPageResponse(Member member, List<Category> categories, List<GetMyPageTeamBlock> blocks) {
+    public static GetMyPageResponse toGetMyPageResponse(Member member, List<String> categories, List<GetMyPageTeamBlock> blocks) {
         return GetMyPageResponse.builder()
                 .profileImage(member.getProfileImage())
                 .nickName(member.getNickName())

--- a/src/main/java/com/moing/backend/domain/mypage/application/service/GetMyPageUseCase.java
+++ b/src/main/java/com/moing/backend/domain/mypage/application/service/GetMyPageUseCase.java
@@ -5,7 +5,6 @@ import com.moing.backend.domain.member.domain.service.MemberGetService;
 import com.moing.backend.domain.mypage.application.dto.response.GetMyPageResponse;
 import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
 import com.moing.backend.domain.mypage.application.mapper.MyPageMapper;
-import com.moing.backend.domain.team.domain.constant.Category;
 import com.moing.backend.domain.team.domain.service.TeamGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,7 +27,7 @@ public class GetMyPageUseCase {
         return MyPageMapper.toGetMyPageResponse(member, calculateCategory(getMyPageTeamBlocks), getMyPageTeamBlocks);
     }
 
-    private static List<Category> calculateCategory(List<GetMyPageTeamBlock> getMyPageTeamBlocks) {
+    private static List<String> calculateCategory(List<GetMyPageTeamBlock> getMyPageTeamBlocks) {
         return getMyPageTeamBlocks.stream()
                 .map(GetMyPageTeamBlock::getCategory)
                 .distinct()

--- a/src/main/java/com/moing/backend/domain/team/application/dto/request/CreateTeamRequest.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/request/CreateTeamRequest.java
@@ -1,7 +1,5 @@
 package com.moing.backend.domain.team.application.dto.request;
 
-import com.moing.backend.domain.team.domain.constant.Category;
-import com.moing.backend.global.annotation.Enum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +14,6 @@ import javax.validation.constraints.Size;
 @Getter
 public class CreateTeamRequest {
     @NotBlank(message = "category 를 입력해 주세요.")
-    @Enum(enumClass = Category.class)
     private String category;
 
     @NotBlank(message = "name 을 입력해 주세요.")

--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/GetNewTeamResponse.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/GetNewTeamResponse.java
@@ -1,6 +1,5 @@
 package com.moing.backend.domain.team.application.dto.response;
 
-import com.moing.backend.domain.team.domain.constant.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 public class GetNewTeamResponse {
 
     private String teamName;
-    private Category category;
+    private String category;
     private String promise;
     private String introduction;
     private String profileImgUrl;

--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/GetTeamDetailResponse.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/GetTeamDetailResponse.java
@@ -1,13 +1,8 @@
 package com.moing.backend.domain.team.application.dto.response;
 
-import com.moing.backend.domain.team.domain.constant.Category;
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/TeamBlock.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/TeamBlock.java
@@ -1,6 +1,5 @@
 package com.moing.backend.domain.team.application.dto.response;
 
-import com.moing.backend.domain.team.domain.constant.Category;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,13 +28,13 @@ public class TeamBlock {
     private String profileImgUrl;
 
     @QueryProjection
-    public TeamBlock(Long teamId, LocalDateTime approvalTime, Integer levelOfFire, String teamName, Integer numOfMember, Category category, LocalDateTime deletionTime, String profileImgUrl) {
+    public TeamBlock(Long teamId, LocalDateTime approvalTime, Integer levelOfFire, String teamName, Integer numOfMember, String category, LocalDateTime deletionTime, String profileImgUrl) {
         this.teamId=teamId;
         this.duration=calculateDuration(approvalTime);
         this.levelOfFire=levelOfFire;
         this.teamName=teamName;
         this.numOfMember=numOfMember;
-        this.category=category.getMessage();
+        this.category = category;
         this.startDate=approvalTime.toLocalDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
         this.deletionTime=deletionTime;
         this.profileImgUrl = profileImgUrl;

--- a/src/main/java/com/moing/backend/domain/team/application/dto/response/TeamInfo.java
+++ b/src/main/java/com/moing/backend/domain/team/application/dto/response/TeamInfo.java
@@ -1,6 +1,5 @@
 package com.moing.backend.domain.team.application.dto.response;
 
-import com.moing.backend.domain.team.domain.constant.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +16,7 @@ public class TeamInfo {
     private LocalDateTime deletionTime;
     private String teamName; //소모임 이름
     private Integer numOfMember; //소모임원 수
-    private Category category; //카테고리
+    private String category; //카테고리
     private String introduction; //소개
     private Long currentUserId; //현재 유저 아이디
     private List<TeamMemberInfo> teamMemberInfoList = new ArrayList<>(); //소모임원 정보

--- a/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
+++ b/src/main/java/com/moing/backend/domain/team/application/mapper/TeamMapper.java
@@ -4,7 +4,6 @@ import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.request.CreateTeamRequest;
 import com.moing.backend.domain.team.application.dto.response.*;
 import com.moing.backend.domain.team.domain.constant.ApprovalStatus;
-import com.moing.backend.domain.team.domain.constant.Category;
 import com.moing.backend.domain.team.domain.entity.Team;
 import org.springframework.stereotype.Component;
 
@@ -18,7 +17,7 @@ public class TeamMapper {
 
     public static Team createTeam(CreateTeamRequest createTeamRequest, Member member) {
         return Team.builder()
-                .category(Enum.valueOf(Category.class, createTeamRequest.getCategory()))
+                .category(createTeamRequest.getCategory())
                 .name(createTeamRequest.getName())
                 .introduction(createTeamRequest.getIntroduction())
                 .promise(createTeamRequest.getPromise())

--- a/src/main/java/com/moing/backend/domain/team/domain/constant/Category.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/constant/Category.java
@@ -1,18 +1,18 @@
-package com.moing.backend.domain.team.domain.constant;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
-public enum Category{
-    SPORTS("스포츠/운동"),
-    HABIT("생활습관 개선"),
-    TEST("시험/취업준비"),
-    STUDY("스터디/공부"),
-    READING("독서"),
-    ETC("그외 자기계발");
-
-    private final String message;
-}
-
+//package com.moing.backend.domain.team.domain.constant;
+//
+//import lombok.Getter;
+//import lombok.RequiredArgsConstructor;
+//
+//@Getter
+//@RequiredArgsConstructor
+//public enum Category{
+//    SPORTS("스포츠/운동"),
+//    HABIT("생활습관 개선"),
+//    TEST("시험/취업준비"),
+//    STUDY("스터디/공부"),
+//    READING("독서"),
+//    ETC("그외 자기계발");
+//
+//    private final String message;
+//}
+//

--- a/src/main/java/com/moing/backend/domain/team/domain/entity/Team.java
+++ b/src/main/java/com/moing/backend/domain/team/domain/entity/Team.java
@@ -2,7 +2,6 @@ package com.moing.backend.domain.team.domain.entity;
 
 import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.team.domain.constant.ApprovalStatus;
-import com.moing.backend.domain.team.domain.constant.Category;
 import com.moing.backend.global.entity.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,9 +26,8 @@ public class Team extends BaseTimeEntity {
     @Column(name = "team_id")
     private Long teamId;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
-    private Category category;
+    private String category;
 
     @Column(nullable = false, length = 10)
     private String name;

--- a/src/test/java/com/moing/backend/domain/mypage/presentation/MypageControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/mypage/presentation/MypageControllerTest.java
@@ -8,7 +8,6 @@ import com.moing.backend.domain.mypage.application.dto.response.GetMyPageRespons
 import com.moing.backend.domain.mypage.application.dto.response.GetMyPageTeamBlock;
 import com.moing.backend.domain.mypage.application.dto.response.GetProfileResponse;
 import com.moing.backend.domain.mypage.application.service.*;
-import com.moing.backend.domain.team.domain.constant.Category;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -117,14 +116,14 @@ public class MypageControllerTest extends CommonControllerTest {
     @Test
     public void get_mypage() throws Exception{
         //given
-        List<Category> categoryList=new ArrayList<>();
-        categoryList.add(Category.SPORTS);
+        List<String> categoryList=new ArrayList<>();
+        categoryList.add("SPORTS");
 
         List<GetMyPageTeamBlock> getMyPageTeamBlocks=new ArrayList<>();
         GetMyPageTeamBlock blocks= GetMyPageTeamBlock.builder()
                 .teamId(1L)
                 .teamName("소모임이름")
-                .category(Category.SPORTS)
+                .category("SPORTS")
                 .profileImgUrl("프로필 이미지 url")
                 .build();
         getMyPageTeamBlocks.add(blocks);

--- a/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/team/presentation/TeamControllerTest.java
@@ -5,7 +5,6 @@ import com.moing.backend.domain.team.application.dto.request.CreateTeamRequest;
 import com.moing.backend.domain.team.application.dto.request.UpdateTeamRequest;
 import com.moing.backend.domain.team.application.dto.response.*;
 import com.moing.backend.domain.team.application.service.*;
-import com.moing.backend.domain.team.domain.constant.Category;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -195,7 +194,7 @@ public class TeamControllerTest extends CommonControllerTest {
                 .deletionTime(LocalDateTime.now())
                 .teamName("소모임 이름")
                 .numOfMember(1)
-                .category(Category.ETC)
+                .category("ETC")
                 .introduction("소모임 소개글")
                 .currentUserId(1L)
                 .teamMemberInfoList(teamMemberInfoList).build();


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 모임 만들 때 카테고리 직접 입력할 수 있게 카테고리 enum 제거

## 변경 사항
- Category enum 클래스는 정적이므로 string으로 수정 
