### PR TITLE
MNG-06 유저가 작성한 공지/게시글에 댓글이 달리면, 해당 유저에게 푸시 알림을 발송하도록 추가

### DIFF
--- a/src/main/java/com/moing/backend/domain/boardComment/application/service/CreateBoardCommentUseCase.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/service/CreateBoardCommentUseCase.java
@@ -21,7 +21,7 @@ public class CreateBoardCommentUseCase {
     private final BoardCommentSaveService boardCommentSaveService;
     private final BaseBoardService baseBoardService;
     private final CheckLeaderUseCase checkLeaderUseCase;
-
+    private final SendCommentAlarmUseCase sendCommentAlarmUseCase;
     /**
      * 게시글 댓글 생성
      */
@@ -32,6 +32,8 @@ public class CreateBoardCommentUseCase {
         BoardComment boardComment = boardCommentSaveService.saveBoardComment(BoardCommentMapper.toBoardComment(data.getTeamMember(), data.getBoard(), createBoardCommentRequest, isLeader));
         // 2. 게시글 댓글 개수 증가
         data.getBoard().incrComNum();
+        // 3. 게시글 댓글 알림
+        sendCommentAlarmUseCase.sendNewUploadAlarm(data, boardComment);
         return new CreateBoardCommentResponse(boardComment.getBoardCommentId());
     }
 }

--- a/src/main/java/com/moing/backend/domain/boardComment/application/service/SendCommentAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/service/SendCommentAlarmUseCase.java
@@ -1,0 +1,53 @@
+package com.moing.backend.domain.boardComment.application.service;
+
+import com.moing.backend.domain.board.domain.entity.Board;
+import com.moing.backend.domain.boardComment.domain.entity.BoardComment;
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
+import com.moing.backend.domain.history.domain.entity.AlarmType;
+import com.moing.backend.domain.history.domain.entity.PagePath;
+import com.moing.backend.domain.member.domain.entity.Member;
+import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.global.config.fcm.dto.event.SingleFcmEvent;
+import com.moing.backend.global.response.BaseBoardServiceResponse;
+import lombok.RequiredArgsConstructor;
+import net.minidev.json.JSONObject;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+
+import static com.moing.backend.domain.history.domain.entity.PagePath.MISSION_PATH;
+import static com.moing.backend.global.config.fcm.constant.NewCommentUploadMessage.NEW_COMMENT_UPLOAD_MESSAGE;
+import static com.moing.backend.global.config.fcm.constant.NewNoticeUploadMessage.NEW_NOTICE_UPLOAD_MESSAGE;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SendCommentAlarmUseCase {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void sendNewUploadAlarm(BaseBoardServiceResponse response, BoardComment comment) {
+        Member member = response.getMember();
+        Team team = response.getTeam();
+        Board board = response.getBoard();
+
+        String title = NEW_COMMENT_UPLOAD_MESSAGE.title(comment.getContent());
+        String body = NEW_COMMENT_UPLOAD_MESSAGE.body(member.getNickName(),board.getTitle());
+
+        // 알림 보내기
+        eventPublisher.publishEvent(new SingleFcmEvent(board.getTeamMember().getMember(), title, body, createIdInfo(team.getTeamId(), board.getBoardId()), team.getName(), AlarmType.NEW_UPLOAD, PagePath.NOTICE_PATH.getValue()));
+
+    }
+
+    private String createIdInfo(Long teamId, Long boardId) {
+        JSONObject jo = new JSONObject();
+        jo.put("teamId", teamId);
+        jo.put("boardId", boardId);
+        return jo.toJSONString();
+    }
+}

--- a/src/main/java/com/moing/backend/global/config/fcm/constant/NewCommentUploadMessage.java
+++ b/src/main/java/com/moing/backend/global/config/fcm/constant/NewCommentUploadMessage.java
@@ -1,0 +1,23 @@
+package com.moing.backend.global.config.fcm.constant;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NewCommentUploadMessage {
+
+    NEW_COMMENT_UPLOAD_MESSAGE("%s", "[%s님의 댓글] %s");
+
+    private final String title;
+    private final String body;
+
+    public String title(String commentContent) {
+        return String.format(title, commentContent);
+    }
+
+    public String body(String writerNickname, String boardTitle) {
+        return String.format(body, writerNickname, boardTitle);
+    }
+}


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 유저가 작성한 공지/게시글에 댓글이 달리면, 해당 유저에게 푸시 알림을 발송하도록 추가

## 변경 사항
- 댓글이 생성되면 그 댓글의 게시글을 쓴 유저에게 알림을 보냄
