### PR TITLE
MNG-08 : 반복 미션 즉시 시작할 수 있도록 유예 기간 해제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 ### yml ###
 application.yml
 application-local.yml
+application-dev.yml
 .DS_Store
 src/main/resources/firebase-key.json
 


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
➡️ 반복 미션을 즉시 시작할 수 있도록 변경함
## 변경 사항
1. 미션 생성시 WAIT 상태로 미션 만들어짐. 
2. 한번 미션은 new 미션! 하고 태그가 뜨도록 함. 팀원 중 누군가가 인증을 하게 된다면 ongoing으로 변경. **그대로 유지**
3. 반복 미션은 유예 상태였음. 한번/반복 미션 공통 MissionMapper 에는 WAIT로 Mission 객체를 만들지만, 반복 미션에 따른 다른 제약 사항, 예외 처리 부분이 있기에 **객체 생성 후 반복미션임을 확인하고 예외를 모두 통과한다면 ONGOING으로 updateStatus 하도록 함** 

## 코드 리뷰 시 참고 사항

## 테스트 결과
