### PR TITLE
MNG-14 fix: 알림 히스토리 전체 조회할 때 모두 읽음 처리

### DIFF
--- a/src/main/java/com/moing/backend/domain/history/application/service/GetAlarmHistoryUseCase.java
+++ b/src/main/java/com/moing/backend/domain/history/application/service/GetAlarmHistoryUseCase.java
@@ -21,7 +21,7 @@ public class GetAlarmHistoryUseCase {
     /**
      * 알림 히스토리 조회
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public List<GetAlarmHistoryResponse> getAllAlarmHistories(String socialId) {
         Member member = memberGetService.getMemberBySocialId(socialId);
         return alarmHistoryGetService.getAlarmHistories(member.getMemberId());

--- a/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/history/domain/repository/AlarmHistoryCustomRepositoryImpl.java
@@ -3,23 +3,28 @@ package com.moing.backend.domain.history.domain.repository;
 import com.moing.backend.domain.history.application.dto.response.GetAlarmHistoryResponse;
 import com.moing.backend.domain.history.application.dto.response.QGetAlarmHistoryResponse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.impl.JPAUpdateClause;
 
 import javax.persistence.EntityManager;
 import java.util.List;
 
 import static com.moing.backend.domain.history.domain.entity.QAlarmHistory.alarmHistory;
+import static com.moing.backend.domain.team.domain.entity.QTeam.team;
 
 public class AlarmHistoryCustomRepositoryImpl implements AlarmHistoryCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    private final EntityManager em;
+
     public AlarmHistoryCustomRepositoryImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
+        this.em = em;
     }
 
     @Override
     public List<GetAlarmHistoryResponse> findAlarmHistoriesByMemberId(Long memberId) {
-        return queryFactory.select(new QGetAlarmHistoryResponse(alarmHistory.id,
+        List<GetAlarmHistoryResponse> response= queryFactory.select(new QGetAlarmHistoryResponse(alarmHistory.id,
                         alarmHistory.type,
                         alarmHistory.path,
                         alarmHistory.idInfo,
@@ -32,8 +37,21 @@ public class AlarmHistoryCustomRepositoryImpl implements AlarmHistoryCustomRepos
                 .where(alarmHistory.receiverId.eq(memberId))
                 .orderBy(alarmHistory.createdDate.desc())
                 .fetch();
+
+        readAlarmHistory(memberId);
+        return response;
     }
 
+    private void readAlarmHistory(Long memberId){
+        queryFactory
+                .update(alarmHistory)
+                .set(alarmHistory.isRead, true)
+                .where(alarmHistory.receiverId.eq(memberId))
+                        .execute();
+
+        em.flush();
+        em.clear();
+    }
     @Override
     public String findUnreadAlarmCount(Long memberId) {
         Long count = queryFactory.select(alarmHistory.count())


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 알림 히스토리 모두 읽음 처리

## 변경 사항
- 알림 히스토리 전체 조회할 때 해당 사용자의 히스토리를 모두 읽음 처리하게 수정 
