### PR TITLE
MNG-10

### DIFF
--- a/src/main/java/com/moing/backend/domain/fire/domain/repository/FireCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/fire/domain/repository/FireCustomRepositoryImpl.java
@@ -1,13 +1,9 @@
 package com.moing.backend.domain.fire.domain.repository;
 
 import com.moing.backend.domain.fire.application.dto.res.FireReceiveRes;
-import com.moing.backend.domain.fire.domain.entity.Fire;
-import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
-import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -20,12 +16,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.moing.backend.domain.fire.domain.entity.QFire.fire;
-import static com.moing.backend.domain.member.domain.entity.QMember.member;
 import static com.moing.backend.domain.mission.domain.entity.QMission.mission;
 import static com.moing.backend.domain.missionArchive.domain.entity.QMissionArchive.missionArchive;
-import static com.moing.backend.domain.team.domain.entity.QTeam.team;
 import static com.moing.backend.domain.teamMember.domain.entity.QTeamMember.teamMember;
-import static com.querydsl.jpa.JPAExpressions.max;
 import static com.querydsl.jpa.JPAExpressions.select;
 
 public class FireCustomRepositoryImpl implements FireCustomRepository {
@@ -53,53 +46,24 @@ public class FireCustomRepositoryImpl implements FireCustomRepository {
         return count <= 0; // 1시간 이내에 생성된 데이터가 존재하면 true를 반환, 그렇지 않으면 false 반환
     }
 
-
     public Optional<List<FireReceiveRes>> getFireReceivers(Long teamId, Long missionId, Long memberId) {
 
-        BooleanExpression dateInRange = createRepeatTypeConditionByArchive();
+        JPQLQuery<Long> todayCompletedMemberOfRepeat = todayRepeatMissionDone(missionId);
 
-        JPQLQuery<Long> missionDonePeople = select(missionArchive.member.memberId)
-                .from(missionArchive, mission)
-                .where(missionArchive.mission.id.eq(missionId),
-                        mission.id.eq(missionId)
-                )
-                .groupBy(missionArchive.member.memberId,
-                        missionArchive.mission.id,
-                        missionArchive.count,
-                        mission.number)
-                .having(
-                        missionArchive.mission.id.eq(missionId),
-                        missionArchive.count.max().goe(mission.number),
-                        (missionArchive.mission.type.eq(MissionType.REPEAT).and(dateInRange)).or(missionArchive.mission.type.eq(MissionType.ONCE))
-                );
-
-        LocalDateTime oneHourAgo = LocalDateTime.now().minusHours(1); // 현재 시간에서 1시간을 뺀 시간
-
-        BooleanExpression oneHourStatus = JPAExpressions
-                .select()
-                .from(fire)
-                .where(
-                        fire.throwMemberId.eq(memberId),
-                        fire.receiveMemberId.notIn(missionDonePeople),
-                        fire.createdDate.after(oneHourAgo) // createdDate가 oneHourAgo 이후인 데이터
-                )
-
-                .exists();
-
+        JPQLQuery<Long> completedMembersOfAll = allMissionDone(missionId);
 
         return Optional.ofNullable(queryFactory
                 .select(Projections.constructor(FireReceiveRes.class,
-                                teamMember.member.memberId,
-                                teamMember.member.nickName,
-                                teamMember.member.profileImage
-//                                oneHourStatus.stringValue()
-//                                teamMember.member.nickName
-                                ))
+                        teamMember.member.memberId,
+                        teamMember.member.nickName,
+                        teamMember.member.profileImage
+                ))
                 .from(teamMember)
                 .where(
                         teamMember.team.teamId.eq(teamId),
                         teamMember.member.memberId.ne(memberId),
-                        teamMember.member.memberId.notIn(missionDonePeople),
+                        teamMember.member.memberId.notIn(completedMembersOfAll)
+                                .and(teamMember.member.memberId.notIn(todayCompletedMemberOfRepeat)),
                         teamMember.isDeleted.ne(Boolean.TRUE)
                 )
                 .fetch());
@@ -113,11 +77,52 @@ public class FireCustomRepositoryImpl implements FireCustomRepository {
         LocalDate startOfWeek = now.with(TemporalAdjusters.previousOrSame(firstDayOfWeek));
         LocalDate endOfWeek = startOfWeek.plusDays(6);
 
-        BooleanExpression dateInRange = missionArchive.createdDate.goe(startOfWeek.atStartOfDay())
+        return missionArchive.createdDate.goe(startOfWeek.atStartOfDay())
                 .and(missionArchive.createdDate.loe(endOfWeek.atStartOfDay().plusDays(1).minusNanos(1)));
-
-        // 조건이 MissionType.REPEAT 인 경우에만 날짜 범위 조건 적용
-        return dateInRange.and(dateInRange);
     }
+
+    private JPQLQuery<Long> todayRepeatMissionDone(Long missionId) {
+        BooleanExpression dateInRange = createRepeatTypeConditionByArchive();
+
+        return
+                select(missionArchive.member.memberId)
+                        .from(missionArchive, mission)
+                        .where(missionArchive.mission.id.eq(missionId),
+                                mission.id.eq(missionId),
+                                (missionArchive.mission.type.eq(MissionType.REPEAT).and(dateInRange)).or(missionArchive.mission.type.eq(MissionType.ONCE))
+                        )
+                        .groupBy(missionArchive.member.memberId,
+                                missionArchive.mission.id,
+                                missionArchive.count,
+                                mission.number,
+                                missionArchive.mission.type,
+                                missionArchive.createdDate)
+                        .having(
+                                missionArchive.mission.id.eq(missionId),
+                                (missionArchive.mission.type.eq(MissionType.REPEAT)).or(missionArchive.mission.type.eq(MissionType.ONCE))
+                        );
+    }
+
+    private JPQLQuery<Long> allMissionDone(Long missionId) {
+
+        BooleanExpression dateInRange = createRepeatTypeConditionByArchive();
+
+        return
+                select(missionArchive.member.memberId)
+                        .from(missionArchive, mission)
+                        .where(missionArchive.mission.id.eq(missionId),
+                                mission.id.eq(missionId),
+                                (missionArchive.mission.type.eq(MissionType.REPEAT).and(dateInRange)).or(missionArchive.mission.type.eq(MissionType.ONCE))
+                        )
+                        .groupBy(missionArchive.member.memberId,
+                                missionArchive.mission.id,
+                                missionArchive.count,
+                                mission.number)
+                        .having(
+                                missionArchive.mission.id.eq(missionId),
+                                missionArchive.count.max().goe(mission.number)
+                        );
+    }
+
 
 }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
➡️ 미션 인증 성공/실패 기준을 '전체 인증 횟수 완료/미완료'가 아닌 '당일 인증 완료/미완료' 여부로 판별
➡️ 당일에 인증을 하지 않은 모임원만 불던지기에 띄우기 (24시간마다 리셋)
➡️ 모든 인증 회차를 채운 모임원은 더 이상 불던지기에 프로필이 등장하지 않음

## 변경 사항
- **[ 당일 인증 여부 판단 쿼리, 모두 인증 완료 판단 쿼리 ]** 의 결과값을 제외하고 return 하기에 .. 쿼리가 조금 길어요 .. 

## 코드 리뷰 시 참고 사항

## 테스트 결과
