### PR TITLE
MNG-15 feat : 차단한 멤버 관리 로직 추가 (게시글/댓글 목록)

### DIFF
--- a/src/main/java/com/moing/backend/domain/block/domain/entity/Block.java
+++ b/src/main/java/com/moing/backend/domain/block/domain/entity/Block.java
@@ -24,4 +24,8 @@ public class Block extends BaseTimeEntity {
     private Long blockMemberId;
     private Long targetId;
 
+    public Block(Long blockMemberId, Long targetId) {
+        this.blockMemberId=blockMemberId;
+        this.targetId=targetId;
+    }
 }

--- a/src/main/java/com/moing/backend/domain/block/domain/repository/BlockRepositoryUtils.java
+++ b/src/main/java/com/moing/backend/domain/block/domain/repository/BlockRepositoryUtils.java
@@ -15,4 +15,13 @@ public class BlockRepositoryUtils {
                         block.targetId.eq(targetMemberId))
                 .notExists();
     }
+
+    public static BooleanExpression blockCondition(NumberPath<Long> memberId, Long targetMemberId) {
+        return JPAExpressions
+                .select(block.id)
+                .from(block)
+                .where(block.blockMemberId.eq(memberId),
+                        block.targetId.eq(targetMemberId))
+                .notExists();
+    }
 }

--- a/src/main/java/com/moing/backend/domain/block/domain/repository/BlockRepositoryUtils.java
+++ b/src/main/java/com/moing/backend/domain/block/domain/repository/BlockRepositoryUtils.java
@@ -1,0 +1,18 @@
+package com.moing.backend.domain.block.domain.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.JPAExpressions;
+
+import static com.moing.backend.domain.block.domain.entity.QBlock.block;
+
+public class BlockRepositoryUtils {
+    public static BooleanExpression blockCondition(Long memberId, NumberPath<Long> targetMemberId) {
+        return JPAExpressions
+                .select(block.id)
+                .from(block)
+                .where(block.blockMemberId.eq(memberId),
+                        block.targetId.eq(targetMemberId))
+                .notExists();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/board/application/dto/response/BoardBlocks.java
+++ b/src/main/java/com/moing/backend/domain/board/application/dto/response/BoardBlocks.java
@@ -60,7 +60,6 @@ public class BoardBlocks {
         if(Boolean.TRUE.equals(writerIsDeleted)) {
             this.writerNickName = "(알 수 없음)";
             this.writerProfileImage = null;
-            this.makerId = 0L;
         }
     }
 }

--- a/src/main/java/com/moing/backend/domain/boardComment/application/dto/response/CommentBlocks.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/dto/response/CommentBlocks.java
@@ -47,7 +47,6 @@ public class CommentBlocks {
 
     public void deleteMember() {
         if (Boolean.TRUE.equals(writerIsDeleted)) {
-            this.makerId = 0L;
             this.writerNickName = "(알 수 없음)";
             this.writerProfileImage = null;
         }

--- a/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.moing.backend.domain.boardComment.domain.repository;
 
+import com.moing.backend.domain.block.domain.repository.BlockRepositoryUtils;
 import com.moing.backend.domain.boardComment.application.dto.response.CommentBlocks;
 import com.moing.backend.domain.boardComment.application.dto.response.GetBoardCommentResponse;
 import com.moing.backend.domain.boardComment.application.dto.response.QCommentBlocks;
@@ -13,8 +14,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import javax.persistence.EntityManager;
 import java.util.List;
 
-import static com.moing.backend.domain.block.domain.entity.QBlock.block;
-import static com.moing.backend.domain.board.domain.entity.QBoard.board;
 import static com.moing.backend.domain.boardComment.domain.entity.QBoardComment.boardComment;
 import static com.moing.backend.domain.member.domain.entity.QMember.member;
 
@@ -30,12 +29,7 @@ public class BoardCommentCustomRepositoryImpl implements BoardCommentCustomRepos
     @Override
     public GetBoardCommentResponse findBoardCommentAll(Long boardId, TeamMember teamMember) {
 
-        BooleanExpression blockCondition = JPAExpressions
-                .select(block.id)
-                .from(block)
-                .where(block.blockMemberId.eq(teamMember.getMember().getMemberId()),
-                        block.targetId.eq(boardComment.teamMember.member.memberId))
-                .notExists();
+        BooleanExpression blockCondition = BlockRepositoryUtils.blockCondition(teamMember.getTeamMemberId(), boardComment.teamMember.member.memberId);
 
         List<CommentBlocks> commentBlocks = queryFactory
                 .select(new QCommentBlocks(

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
@@ -1,18 +1,12 @@
 package com.moing.backend.domain.teamMember.domain.repository;
 
-import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
 import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
-import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
-import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface TeamMemberCustomRepository {
-    List<Long> findMemberIdsByTeamId(Long teamId);
     Optional<List<NewUploadInfo>> findNewUploadInfo(Long teamId, Long memberId);
-    Optional<List<String>> findFcmTokensByTeamIdAndMemberId(Long teamId, Long memberId);
     List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long teamId);
-    List<TeamMember> findTeamMemberByMemberId(Long memberId);
 }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
@@ -1,11 +1,11 @@
 package com.moing.backend.domain.teamMember.domain.repository;
 
-import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.block.domain.repository.BlockRepositoryUtils;
 import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.team.application.dto.response.QTeamMemberInfo;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
-import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
@@ -23,17 +23,9 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
     }
 
     @Override
-    public List<Long> findMemberIdsByTeamId(Long teamId) {
-        return queryFactory
-                .select(teamMember.member.memberId)
-                .from(teamMember)
-                .where(teamMember.team.teamId.eq(teamId)
-                        .and(teamMember.team.isDeleted.eq(false)))
-                .fetch();
-    }
-
-    @Override
     public Optional<List<NewUploadInfo>> findNewUploadInfo(Long teamId, Long memberId) {
+        BooleanExpression blockCondition= BlockRepositoryUtils.blockCondition(teamMember.member.memberId, memberId);
+
         List<NewUploadInfo> result = queryFactory.select(Projections.constructor(NewUploadInfo.class,
                         teamMember.member.fcmToken,
                         teamMember.member.memberId,
@@ -42,21 +34,8 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
                 .from(teamMember)
                 .where(teamMember.team.teamId.eq(teamId)
                         .and(teamMember.member.memberId.ne(memberId))
-                        .and(teamMember.isDeleted.eq(false)))
-                .fetch();
-
-        return result.isEmpty() ? Optional.empty() : Optional.of(result);
-    }
-
-    @Override
-    public Optional<List<String>> findFcmTokensByTeamIdAndMemberId(Long teamId, Long memberId) {
-        List<String> result = queryFactory.select(teamMember.member.fcmToken)
-                .from(teamMember)
-                .where(teamMember.team.teamId.eq(teamId)
-                        .and(teamMember.member.isNewUploadPush.eq(true))
-                        .and(teamMember.member.isSignOut.eq(false))
-                        .and(teamMember.member.memberId.ne(memberId))
-                        .and(teamMember.isDeleted.eq(false)))
+                        .and(teamMember.isDeleted.eq(false)
+                                .and(blockCondition)))
                 .fetch();
 
         return result.isEmpty() ? Optional.empty() : Optional.of(result);
@@ -79,11 +58,4 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
                 .fetch();
     }
 
-    @Override
-    public List<TeamMember> findTeamMemberByMemberId(Long memberId) {
-        return queryFactory.selectFrom(teamMember)
-                .where(teamMember.member.memberId.eq(memberId)
-                        .and(teamMember.isDeleted.eq(false)))
-                .fetch();
-    }
 }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
@@ -1,6 +1,5 @@
 package com.moing.backend.domain.teamMember.domain.service;
 
-import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
 import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.application.dto.response.TeamMemberInfo;
@@ -19,10 +18,6 @@ import java.util.Optional;
 public class TeamMemberGetService {
     private final TeamMemberRepository teamMemberRepository;
 
-    public List<Long> getTeamMemberIds(Long teamId){
-        return teamMemberRepository.findMemberIdsByTeamId(teamId);
-    }
-
     public TeamMember getTeamMember(Member member, Team team){
         return teamMemberRepository.findTeamMemberByTeamAndMember(team, member).orElseThrow(NotFoundByTeamIdException::new);
     }
@@ -34,16 +29,8 @@ public class TeamMemberGetService {
     }
 
 
-    public Optional<List<String>> getFcmTokensExceptMe(Long teamId, Long memberId) {
-        return teamMemberRepository.findFcmTokensByTeamIdAndMemberId(teamId, memberId);
-    }
-
     public List<TeamMemberInfo> getTeamMemberInfo(Long teamId){
         return teamMemberRepository.findTeamMemberInfoByTeamId(teamId);
-    }
-
-    public List<TeamMember> getNotDeletedTeamMember(Long memberId){
-        return teamMemberRepository.findTeamMemberByMemberId(memberId);
     }
 
     public Optional<List<NewUploadInfo>> getNewUploadInfo(Long teamId, Long memberId) {

--- a/src/test/java/com/moing/backend/domain/board/domain/BoardRepositoryTest.java
+++ b/src/test/java/com/moing/backend/domain/board/domain/BoardRepositoryTest.java
@@ -159,6 +159,20 @@ public class BoardRepositoryTest {
 
         //then
         assertThat(response.getNotNoticeBlocks().size()).isEqualTo(0);
-
     }
+
+    @Test
+    @DisplayName("유저 차단 경우 목표보드 게시글 개수")
+    void 유저_차단_게시글_조회(){
+        //given
+        Board board = boardRepository.save(BoardMapper.toBoard(tm2NotDeleted, team, createBoardRequest, false)); //작성자 탈퇴한 경우
+        Block block = blockRepository.save(new Block(checkingMember.getMemberId(), member2.getMemberId()));
+
+        //when
+        Integer unReadBoardNum= boardRepository.findUnReadBoardNum(team.getTeamId(), checkingMember.getMemberId());
+
+        //then
+        assertThat(unReadBoardNum).isEqualTo(0);
+    }
+
 }

--- a/src/test/java/com/moing/backend/domain/board/domain/BoardRepositoryTest.java
+++ b/src/test/java/com/moing/backend/domain/board/domain/BoardRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.moing.backend.domain.board.domain;
 
+import com.moing.backend.domain.block.domain.entity.Block;
+import com.moing.backend.domain.block.domain.repository.BlockRepository;
 import com.moing.backend.domain.board.application.dto.request.CreateBoardRequest;
 import com.moing.backend.domain.board.application.dto.response.GetAllBoardResponse;
 import com.moing.backend.domain.board.application.mapper.BoardMapper;
@@ -23,7 +25,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,17 +53,21 @@ public class BoardRepositoryTest {
     @Autowired
     BoardReadRepository boardReadRepository;
 
-    private Member minsu, seungyeon;
+    @Autowired
+    BlockRepository blockRepository;
+
+    private Member checkingMember, member1, member2;
 
     private Team team;
-    private TeamMember deletedTM, validTM;
+    private TeamMember checkingTM, tm1Deleted, tm2NotDeleted;
     private CreateBoardRequest createBoardRequest;
 
     @BeforeEach
     void setUp() {
         //given
-        minsu = memberRepository.save(new Member(null, "minsu@naver.com", "undef", Gender.WOMAN, null, "민수", null, SocialProvider.KAKAO, RegistrationStatus.COMPLETED, Role.USER, "KAKAO@minsu"));
-        seungyeon = memberRepository.save(new Member(null, "seungyeon@naver.com", "undef", Gender.WOMAN, null, "승연", null, SocialProvider.KAKAO, RegistrationStatus.COMPLETED, Role.USER, "KAKAO@seungyeon"));
+        checkingMember = memberRepository.save(new Member(null, "alstn@naver.com", "undef", Gender.WOMAN, null, "민수", null, SocialProvider.KAKAO, RegistrationStatus.COMPLETED, Role.USER, "KAKAO@alstn"));
+        member1 = memberRepository.save(new Member(null, "tmddus@naver.com", "undef", Gender.WOMAN, null, "승연", null, SocialProvider.KAKAO, RegistrationStatus.COMPLETED, Role.USER, "KAKAO@tmddus"));
+        member2 = memberRepository.save(new Member(null, "codud@naver.com", "undef", Gender.WOMAN, null, "채영", null, SocialProvider.KAKAO, RegistrationStatus.COMPLETED, Role.USER, "KAKAO@codud"));
 
         team = teamRepository.save(Team.builder()
                 .category("ETC")
@@ -76,8 +81,9 @@ public class BoardRepositoryTest {
                 .levelOfFire(1)
                 .build());
 
-        validTM=teamMemberRepository.save(TeamMember.builder().team(team).member(minsu).isDeleted(false).build());
-        deletedTM=teamMemberRepository.save(TeamMember.builder().team(team).member(seungyeon).isDeleted(true).build());
+        checkingTM = teamMemberRepository.save(TeamMember.builder().team(team).member(checkingMember).isDeleted(false).build());
+        tm1Deleted = teamMemberRepository.save(TeamMember.builder().team(team).member(member1).isDeleted(true).build());
+        tm2NotDeleted = teamMemberRepository.save(TeamMember.builder().team(team).member(member2).isDeleted(true).build());
 
         createBoardRequest = CreateBoardRequest.builder()
                 .title("게시글 제목")
@@ -90,12 +96,12 @@ public class BoardRepositoryTest {
     @DisplayName("게시글을 읽은 경우")
     void whenBoardIsRead_thenMarkAsRead() {
         //given
-        Board board = boardRepository.save(BoardMapper.toBoard(validTM, team, createBoardRequest, false));
+        Board board = boardRepository.save(BoardMapper.toBoard(checkingTM, team, createBoardRequest, false));
 
-        boardReadRepository.save(new BoardRead(null, board, team, minsu));
+        boardReadRepository.save(new BoardRead(null, board, team, checkingMember));
 
         //when
-        GetAllBoardResponse response = boardRepository.findBoardAll(team.getTeamId(), minsu.getMemberId());
+        GetAllBoardResponse response = boardRepository.findBoardAll(team.getTeamId(), checkingMember.getMemberId());
 
         //then
         assertThat(response.getNotNoticeBlocks().get(0).getIsRead()).isTrue();
@@ -105,10 +111,10 @@ public class BoardRepositoryTest {
     @DisplayName("게시글을 읽지 않은 경우")
     void whenBoardIsNotRead_thenMarkAsUnread() {
         //given
-        Board board = boardRepository.save(BoardMapper.toBoard(validTM, team, createBoardRequest, false));
-        
+        Board board = boardRepository.save(BoardMapper.toBoard(checkingTM, team, createBoardRequest, false));
+
         //when
-        GetAllBoardResponse response = boardRepository.findBoardAll(team.getTeamId(), minsu.getMemberId());
+        GetAllBoardResponse response = boardRepository.findBoardAll(team.getTeamId(), checkingMember.getMemberId());
 
         //then
         assertThat(response.getNotNoticeBlocks().get(0).getIsRead()).isFalse();
@@ -117,12 +123,42 @@ public class BoardRepositoryTest {
     @DisplayName("작성자가 삭제된 경우")
     void 게시글_작성자가_탈퇴하지_않은_경우_게시글_전체_조회() {
         //given
-        Board board = boardRepository.save(BoardMapper.toBoard(deletedTM, team, createBoardRequest, false)); //작성자 탈퇴한 경우
+        Board board = boardRepository.save(BoardMapper.toBoard(tm1Deleted, team, createBoardRequest, false)); //작성자 탈퇴한 경우
 
         //when
-        GetAllBoardResponse response=boardRepository.findBoardAll(team.getTeamId(),minsu.getMemberId());
+        GetAllBoardResponse response = boardRepository.findBoardAll(team.getTeamId(), checkingMember.getMemberId());
 
         //then
         assertThat(response.getNotNoticeBlocks().get(0).getWriterNickName()).isEqualTo("(알 수 없음)");
+    }
+
+    @Test
+    @DisplayName("유저 차단 경우 작성자 탈퇴 아님")
+    void 유저_탈퇴안했을때_차단_조회() {
+        //given
+        Board board = boardRepository.save(BoardMapper.toBoard(tm2NotDeleted, team, createBoardRequest, false)); //작성자 탈퇴한 경우
+        Block block = blockRepository.save(new Block(checkingMember.getMemberId(), member2.getMemberId()));
+
+        //when
+        GetAllBoardResponse response = boardRepository.findBoardAll(team.getTeamId(), checkingMember.getMemberId());
+
+        //then
+        assertThat(response.getNotNoticeBlocks().size()).isEqualTo(0);
+
+    }
+
+    @Test
+    @DisplayName("유저 차단 경우 작성자 탈퇴")
+    void 유저_탈퇴했을때_차단_조회() {
+        //given
+        Board board = boardRepository.save(BoardMapper.toBoard(tm1Deleted, team, createBoardRequest, false)); //작성자 탈퇴한 경우
+        Block block = blockRepository.save(new Block(checkingMember.getMemberId(), member1.getMemberId()));
+
+        //when
+        GetAllBoardResponse response = boardRepository.findBoardAll(team.getTeamId(), checkingMember.getMemberId());
+
+        //then
+        assertThat(response.getNotNoticeBlocks().size()).isEqualTo(0);
+
     }
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 기존에는 프론트엔드에서 처리했지만 로딩 시간이 지연되어서 서버에서 아예 처리하고 보내주려고 합니닷 !!

## 변경 사항
- 차단한 멤버가 작성한 게시글 / 댓글 보이지 않기
- 목표보드 안 읽은 게시글에서 차단한 멤버가 작성한 것 제외
- 차단한 멤버가 새로 만든 공지 / 미션은 포함하지 않음 
++) 게시글 댓글 관련 알림은 어차피 수정될 것 같아 우선 건드리지 않았습니다 !

## 코드 리뷰 시 참고 사항
- BlockRepositoryUtils.blockCondition()함수를 static으로 만들고 이를 호출하는 형식으로 했습니다 !!
