### PR TITLE
MNG-17 feat: 댓글 작성자에게도 알림 가게 기능 추가

### DIFF
--- a/src/main/java/com/moing/backend/domain/boardComment/application/service/SendCommentAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/service/SendCommentAlarmUseCase.java
@@ -2,10 +2,15 @@ package com.moing.backend.domain.boardComment.application.service;
 
 import com.moing.backend.domain.board.domain.entity.Board;
 import com.moing.backend.domain.boardComment.domain.entity.BoardComment;
+import com.moing.backend.domain.boardComment.domain.service.BoardCommentGetService;
+import com.moing.backend.domain.history.application.dto.response.MemberIdAndToken;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
+import com.moing.backend.domain.history.application.mapper.AlarmHistoryMapper;
 import com.moing.backend.domain.history.domain.entity.AlarmType;
 import com.moing.backend.domain.history.domain.entity.PagePath;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.global.config.fcm.dto.event.MultiFcmEvent;
 import com.moing.backend.global.config.fcm.dto.event.SingleFcmEvent;
 import com.moing.backend.global.response.BaseBoardServiceResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +19,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.moing.backend.global.config.fcm.constant.NewCommentUploadMessage.NEW_COMMENT_UPLOAD_MESSAGE;
 
@@ -25,20 +31,34 @@ import static com.moing.backend.global.config.fcm.constant.NewCommentUploadMessa
 public class SendCommentAlarmUseCase {
 
     private final ApplicationEventPublisher eventPublisher;
+    private final BoardCommentGetService boardCommentGetService;
 
     public void sendNewUploadAlarm(BaseBoardServiceResponse response, BoardComment comment) {
         Member member = response.getMember();
         Team team = response.getTeam();
         Board board = response.getBoard();
-        Member receiver = board.getTeamMember().getMember();
 
         String title = NEW_COMMENT_UPLOAD_MESSAGE.title(comment.getContent());
         String body = NEW_COMMENT_UPLOAD_MESSAGE.body(member.getNickName(),board.getTitle());
 
-        // 알림 보내기
-        if(checkBoardWriter(receiver, member)){
+        sendBoardWriter(board, member, title, body, team);
+        sendBoardCommentWriter(board, member, title, body, team);
+    }
+
+    private void sendBoardWriter(Board board, Member member, String title, String body, Team team) {
+        Member receiver = board.getTeamMember().getMember();
+
+        if (checkBoardWriter(receiver, member)) {
             eventPublisher.publishEvent(new SingleFcmEvent(receiver, title, body, createIdInfo(team.getTeamId(), board.getBoardId()), team.getName(), AlarmType.NEW_UPLOAD, PagePath.NOTICE_PATH.getValue(), receiver.isNewUploadPush()));
         }
+    }
+
+    private void sendBoardCommentWriter(Board board, Member member, String title, String body, Team team) {
+        Optional<List<NewUploadInfo>> newUploadInfos = boardCommentGetService.getNewUploadInfo(member.getMemberId(), board.getBoardId());
+        Optional<List<MemberIdAndToken>> memberIdAndTokensByPush = AlarmHistoryMapper.getNewUploadPushInfo(newUploadInfos);
+        Optional<List<MemberIdAndToken>> memberIdAndTokensBySave = AlarmHistoryMapper.getNewUploadSaveInfo(newUploadInfos);
+
+        eventPublisher.publishEvent(new MultiFcmEvent(title, body, memberIdAndTokensByPush, memberIdAndTokensBySave, createIdInfo(team.getTeamId(), board.getBoardId()), team.getName(), AlarmType.NEW_UPLOAD, PagePath.NOTICE_PATH.getValue()));
     }
 
     private String createIdInfo(Long teamId, Long boardId) {
@@ -48,7 +68,9 @@ public class SendCommentAlarmUseCase {
         return jo.toJSONString();
     }
 
-    private boolean checkBoardWriter(Member boardWriter, Member commentWriter){
+    private boolean checkBoardWriter(Member boardWriter, Member commentWriter) { //댓글 작성자와 게시글 작성자가 동일한 경우
         return !Objects.equals(boardWriter.getMemberId(), commentWriter.getMemberId());
     }
+
+
 }

--- a/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepository.java
@@ -1,8 +1,14 @@
 package com.moing.backend.domain.boardComment.domain.repository;
 
 import com.moing.backend.domain.boardComment.application.dto.response.GetBoardCommentResponse;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface BoardCommentCustomRepository {
     GetBoardCommentResponse findBoardCommentAll(Long boardId, TeamMember teamMember);
+
+    Optional<List<NewUploadInfo>> findNewUploadInfo(Long memberId, Long boardId);
 }

--- a/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/domain/repository/BoardCommentCustomRepositoryImpl.java
@@ -4,18 +4,22 @@ import com.moing.backend.domain.block.domain.repository.BlockRepositoryUtils;
 import com.moing.backend.domain.boardComment.application.dto.response.CommentBlocks;
 import com.moing.backend.domain.boardComment.application.dto.response.GetBoardCommentResponse;
 import com.moing.backend.domain.boardComment.application.dto.response.QCommentBlocks;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.teamMember.domain.entity.QTeamMember;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 
 import static com.moing.backend.domain.boardComment.domain.entity.QBoardComment.boardComment;
 import static com.moing.backend.domain.member.domain.entity.QMember.member;
+import static com.moing.backend.domain.teamMember.domain.entity.QTeamMember.teamMember;
 
 public class BoardCommentCustomRepositoryImpl implements BoardCommentCustomRepository{
 
@@ -56,5 +60,27 @@ public class BoardCommentCustomRepositoryImpl implements BoardCommentCustomRepos
                 .fetch();
 
         return new GetBoardCommentResponse(commentBlocks);
+    }
+
+    @Override
+    public Optional<List<NewUploadInfo>> findNewUploadInfo(Long memberId, Long boardId) {
+        BooleanExpression blockCondition= BlockRepositoryUtils.blockCondition(boardComment.teamMember.member.memberId, memberId);
+
+        List<NewUploadInfo> result = queryFactory.select(Projections.constructor(NewUploadInfo.class,
+                        boardComment.teamMember.member.fcmToken,
+                        boardComment.teamMember.member.memberId,
+                        boardComment.teamMember.member.isNewUploadPush,
+                        boardComment.teamMember.member.isSignOut))
+                .distinct()
+                .from(teamMember)
+                .leftJoin(boardComment.teamMember, QTeamMember.teamMember)
+                .leftJoin(boardComment.teamMember.member, member)
+                .where(boardComment.board.boardId.eq(boardId) //게시글의 댓글인데
+                        .and(boardComment.teamMember.member.memberId.ne(memberId)) //나는 포함 안하고
+                        .and(boardComment.teamMember.isDeleted.eq(false)) //탈퇴한 사람도 포함 안함
+                                .and(blockCondition))
+                .fetch();
+
+        return result.isEmpty() ? Optional.empty() : Optional.of(result);
     }
 }

--- a/src/main/java/com/moing/backend/domain/boardComment/domain/service/BoardCommentGetService.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/domain/service/BoardCommentGetService.java
@@ -4,11 +4,14 @@ import com.moing.backend.domain.boardComment.application.dto.response.GetBoardCo
 import com.moing.backend.domain.boardComment.domain.entity.BoardComment;
 import com.moing.backend.domain.boardComment.domain.repository.BoardCommentRepository;
 import com.moing.backend.domain.boardComment.exception.NotFoundByBoardCommentIdException;
+import com.moing.backend.domain.history.application.dto.response.NewUploadInfo;
 import com.moing.backend.domain.teamMember.domain.entity.TeamMember;
 import com.moing.backend.global.annotation.DomainService;
 import lombok.RequiredArgsConstructor;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
 
 @DomainService
 @Transactional
@@ -23,5 +26,9 @@ public class BoardCommentGetService {
 
     public GetBoardCommentResponse getBoardCommentAll(Long boardId, TeamMember teamMember){
         return boardCommentRepository.findBoardCommentAll(boardId, teamMember);
+    }
+
+    public Optional<List<NewUploadInfo>> getNewUploadInfo(Long memberId, Long boardId) {
+        return boardCommentRepository.findNewUploadInfo(memberId, boardId);
     }
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 댓글 작성자에게도 알림 가게 기능 추가

## 변경 사항
- 기존에는 해당 게시글 작성자에게만 알림이 가게 했다면 이제는 거기에 더해 댓글 작성자에게도 알림이 가게 수정
- 댓글 알림에도 차단 멤버 관리 로직이 추가됨

## 코드 리뷰 시 참고 사항
- 댓글 알림 로직... 저게 최선인것인가 ??
 
## 테스트 결과
