### PR TITLE
MNG-15 fix: 차단 멤버 관리 : 모인원 소개, 미션 인증, 불 던지기

### DIFF
--- a/src/main/java/com/moing/backend/domain/fire/domain/repository/FireCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/fire/domain/repository/FireCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.moing.backend.domain.fire.domain.repository;
 
+import com.moing.backend.domain.block.domain.repository.BlockRepositoryUtils;
 import com.moing.backend.domain.fire.application.dto.res.FireReceiveRes;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
 import com.querydsl.core.types.Projections;
@@ -52,6 +53,8 @@ public class FireCustomRepositoryImpl implements FireCustomRepository {
 
         JPQLQuery<Long> completedMembersOfAll = allMissionDone(missionId);
 
+        BooleanExpression blockCondition= BlockRepositoryUtils.blockCondition(memberId, teamMember.member.memberId);
+
         return Optional.ofNullable(queryFactory
                 .select(Projections.constructor(FireReceiveRes.class,
                         teamMember.member.memberId,
@@ -64,7 +67,8 @@ public class FireCustomRepositoryImpl implements FireCustomRepository {
                         teamMember.member.memberId.ne(memberId),
                         teamMember.member.memberId.notIn(completedMembersOfAll)
                                 .and(teamMember.member.memberId.notIn(todayCompletedMemberOfRepeat)),
-                        teamMember.isDeleted.ne(Boolean.TRUE)
+                        teamMember.isDeleted.ne(Boolean.TRUE),
+                        blockCondition
                 )
                 .fetch());
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
@@ -1,11 +1,10 @@
 package com.moing.backend.domain.missionArchive.domain.repository;
 
-import com.moing.backend.domain.board.application.dto.response.BoardBlocks;
+import com.moing.backend.domain.block.domain.repository.BlockRepositoryUtils;
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.mission.application.dto.res.FinishMissionBoardRes;
 import com.moing.backend.domain.mission.application.dto.res.RepeatMissionBoardRes;
 import com.moing.backend.domain.mission.application.dto.res.SingleMissionBoardRes;
-import com.moing.backend.domain.mission.domain.entity.QMission;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionStatus;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionWay;
@@ -13,11 +12,7 @@ import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiv
 import com.moing.backend.domain.missionArchive.application.dto.res.MyArchiveStatus;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchiveStatus;
-import com.moing.backend.domain.missionArchive.domain.entity.QMissionArchive;
-import com.moing.backend.domain.missionRead.domain.entity.QMissionRead;
 import com.moing.backend.domain.missionRead.domain.repository.MissionReadRepositoryUtils;
-import com.moing.backend.domain.team.domain.entity.QTeam;
-import com.moing.backend.domain.teamMember.domain.entity.QTeamMember;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
@@ -27,14 +22,10 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import feign.Param;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.jpa.repository.Query;
 
 import javax.persistence.EntityManager;
-import javax.swing.text.html.Option;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -43,18 +34,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.moing.backend.domain.board.domain.entity.QBoard.board;
-import static com.moing.backend.domain.boardRead.domain.entity.QBoardRead.boardRead;
-import static com.moing.backend.domain.member.domain.entity.QMember.member;
 import static com.moing.backend.domain.mission.domain.entity.QMission.mission;
-import static com.moing.backend.domain.missionArchive.domain.entity.QMissionArchive.*;
-import static com.moing.backend.domain.missionRead.domain.entity.QMissionRead.missionRead;
+import static com.moing.backend.domain.missionArchive.domain.entity.QMissionArchive.missionArchive;
 import static com.moing.backend.domain.missionState.domain.entity.QMissionState.missionState;
-import static com.moing.backend.domain.team.domain.entity.QTeam.team;
 import static com.moing.backend.domain.teamMember.domain.entity.QTeamMember.teamMember;
-import static javax.swing.Spring.constant;
-import static org.springframework.data.jpa.domain.Specification.not;
-import static org.springframework.data.jpa.domain.Specification.where;
 
 @Slf4j
 public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomRepository {
@@ -192,6 +175,8 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
 
         BooleanExpression dateInRange = createRepeatTypeConditionByArchive();
 
+        BooleanExpression blockCondition= BlockRepositoryUtils.blockCondition(memberId, missionArchive.member.memberId);
+
         return Optional.ofNullable(queryFactory
                 .select(missionArchive)
                 .from(missionArchive)
@@ -200,7 +185,7 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
                         missionArchive.member.memberId.ne(memberId),
                         missionArchive.status.eq(MissionArchiveStatus.COMPLETE).or(missionArchive.status.eq(MissionArchiveStatus.SKIP)),
                         (missionArchive.mission.type.eq(MissionType.REPEAT)
-                                .and(missionArchive.mission.status.eq(MissionStatus.ONGOING)).and(dateInRange))
+                                .and(missionArchive.mission.status.eq(MissionStatus.ONGOING)).and(dateInRange)).and(blockCondition)
                                 .or(missionArchive.mission.type.eq(MissionType.REPEAT)
                                         .and(missionArchive.mission.status.eq(MissionStatus.END)))
                                 .or(missionArchive.mission.type.eq(MissionType.ONCE))

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/repository/MissionArchiveCustomRepositoryImpl.java
@@ -184,8 +184,9 @@ public class MissionArchiveCustomRepositoryImpl implements MissionArchiveCustomR
                         missionArchive.mission.id.eq(missionId),
                         missionArchive.member.memberId.ne(memberId),
                         missionArchive.status.eq(MissionArchiveStatus.COMPLETE).or(missionArchive.status.eq(MissionArchiveStatus.SKIP)),
+                        blockCondition,
                         (missionArchive.mission.type.eq(MissionType.REPEAT)
-                                .and(missionArchive.mission.status.eq(MissionStatus.ONGOING)).and(dateInRange)).and(blockCondition)
+                                .and(missionArchive.mission.status.eq(MissionStatus.ONGOING)).and(dateInRange))
                                 .or(missionArchive.mission.type.eq(MissionType.REPEAT)
                                         .and(missionArchive.mission.status.eq(MissionStatus.END)))
                                 .or(missionArchive.mission.type.eq(MissionType.ONCE))

--- a/src/main/java/com/moing/backend/domain/team/application/service/GetTeamUseCase.java
+++ b/src/main/java/com/moing/backend/domain/team/application/service/GetTeamUseCase.java
@@ -33,7 +33,7 @@ public class GetTeamUseCase {
     public GetTeamDetailResponse getTeamDetailResponse(String socialId, Long teamId) {
         Member member = memberGetService.getMemberBySocialId(socialId);
         Integer boardNum = boardGetService.getUnReadBoardNum(teamId, member.getMemberId());
-        List<TeamMemberInfo> teamMemberInfoList = teamMemberGetService.getTeamMemberInfo(teamId);
+        List<TeamMemberInfo> teamMemberInfoList = teamMemberGetService.getTeamMemberInfo(member.getMemberId(), teamId);
         Team team = teamGetService.getTeamByTeamId(teamId);
         return TeamMapper.toTeamDetailResponse(member.getMemberId(), team, boardNum, teamMemberInfoList);
     }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface TeamMemberCustomRepository {
     Optional<List<NewUploadInfo>> findNewUploadInfo(Long teamId, Long memberId);
-    List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long teamId);
+    List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long memberId, Long teamId);
 }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/repository/TeamMemberCustomRepositoryImpl.java
@@ -42,7 +42,11 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
     }
 
     @Override
-    public List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long teamId){
+    public List<TeamMemberInfo> findTeamMemberInfoByTeamId(Long memberId, Long teamId){
+
+        BooleanExpression blockCondition= BlockRepositoryUtils.blockCondition(memberId, teamMember.member.memberId);
+
+
         return queryFactory
                 .select(new QTeamMemberInfo(
                         teamMember.member.memberId,
@@ -53,7 +57,8 @@ public class TeamMemberCustomRepositoryImpl implements TeamMemberCustomRepositor
                 .from(teamMember)
                 .innerJoin(teamMember.team, team) // innerJoin을 사용하여 최적화
                 .where(teamMember.team.teamId.eq(teamId) // where 절을 하나로 합침
-                        .and(teamMember.isDeleted.eq(false)))
+                        .and(teamMember.isDeleted.eq(false))
+                        .and(blockCondition))
                 .groupBy(teamMember.member.memberId)
                 .fetch();
     }

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/service/TeamMemberGetService.java
@@ -29,8 +29,8 @@ public class TeamMemberGetService {
     }
 
 
-    public List<TeamMemberInfo> getTeamMemberInfo(Long teamId){
-        return teamMemberRepository.findTeamMemberInfoByTeamId(teamId);
+    public List<TeamMemberInfo> getTeamMemberInfo(Long memberId, Long teamId){
+        return teamMemberRepository.findTeamMemberInfoByTeamId(memberId, teamId);
     }
 
     public Optional<List<NewUploadInfo>> getNewUploadInfo(Long teamId, Long memberId) {


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
-  기존에는 클라이언트가 처리했던 부분(차단 멤버 관리)을 서버에서 처리하게 수정

## 변경 사항
- 모임원 소개에 차단 멤버 보이지 않게
- 미션 인증물 조회에서 차단 멤버가 한 것은 보이지 않게
- 불 던질 사람 조회할 때 차단 멤버 보이지 않게

## 코드 리뷰 시 참고 사항
- 미션쪽과 불 던지기 부분 확인 부탁 드립니다 :)
