### PR TITLE
MNG 18

### DIFF
--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveCreateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveCreateUseCase.java
@@ -19,6 +19,7 @@ import com.moing.backend.domain.missionState.domain.service.MissionStateSaveServ
 import com.moing.backend.domain.missionHeart.domain.service.MissionHeartQueryService;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.teamScore.application.service.TeamScoreUpdateUseCase;
+import com.moing.backend.domain.teamScore.domain.entity.ScoreStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -96,7 +97,7 @@ public class MissionArchiveCreateUseCase {
             gainBonusScore(mission, newArchive);
         }
         // TODO : 미션 인증 1회당 점수
-        teamScoreUpdateUseCase.gainScoreOfArchive(mission);
+        teamScoreUpdateUseCase.gainScoreOfArchive(mission, ScoreStatus.PLUS);
 
         return missionArchiveRes;
     }
@@ -113,13 +114,11 @@ public class MissionArchiveCreateUseCase {
             if (isAbleToFinishOnceMission(mission)) {
                 mission.updateStatus(MissionStatus.SUCCESS);
                 teamScoreUpdateUseCase.gainScoreOfBonus(mission);
-                log.info("isAbleToFinishOnceMission");
             }
 
         } else {
             if (isAbleToFinishRepeatMission(mission, missionArchive)) {
                 teamScoreUpdateUseCase.gainScoreOfBonus(mission);
-                log.info("isAbleToFinishRepeatMission");
 
             }
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveCreateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveCreateUseCase.java
@@ -32,14 +32,10 @@ public class MissionArchiveCreateUseCase {
 
     private final MissionArchiveSaveService missionArchiveSaveService;
     private final MissionArchiveQueryService missionArchiveQueryService;
-    private final MissionArchiveDeleteService missionArchiveDeleteService;
-
-    private final MissionHeartQueryService missionHeartQueryService;
 
     private final MissionQueryService missionQueryService;
     private final MemberGetService memberGetService;
 
-    private final MissionStateSaveService missionStateSaveService;
     private final MissionStateUseCase missionStateUseCase;
 
     private final TeamScoreUpdateUseCase teamScoreUpdateUseCase;

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveDeleteUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveDeleteUseCase.java
@@ -23,6 +23,8 @@ import com.moing.backend.domain.missionState.domain.service.MissionStateDeleteSe
 import com.moing.backend.domain.missionState.domain.service.MissionStateQueryService;
 import com.moing.backend.domain.missionState.domain.service.MissionStateSaveService;
 import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.domain.teamScore.application.service.TeamScoreUpdateUseCase;
+import com.moing.backend.domain.teamScore.domain.entity.ScoreStatus;
 import com.moing.backend.global.utils.UpdateUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -47,6 +49,8 @@ public class MissionArchiveDeleteUseCase {
     private final MissionStateDeleteService missionStateDeleteService;
     private final MissionStateQueryService missionStateQueryService;
 
+    private final TeamScoreUpdateUseCase teamScoreUpdateUseCase;
+
     private final UpdateUtils updateUtils;
 
 
@@ -55,10 +59,11 @@ public class MissionArchiveDeleteUseCase {
 
         Member member = memberGetService.getMemberBySocialId(userSocialId);
         Long memberId = member.getMemberId();
+
         Mission mission = missionQueryService.findMissionById(missionId);
         Team team = mission.getTeam();
 
-        MissionArchive deleteArchive = missionArchiveQueryService.findOneMyArchive(memberId, missionId,count).get(0);
+        MissionArchive deleteArchive = missionArchiveQueryService.findOneMyArchive(memberId, missionId,count);
         MissionState missionState = missionStateQueryService.findMissionState(member, mission);
 
         LocalDateTime createdDate = deleteArchive.getCreatedDate();
@@ -76,6 +81,8 @@ public class MissionArchiveDeleteUseCase {
 
         missionArchiveDeleteService.deleteMissionArchive(deleteArchive);
         missionStateDeleteService.deleteMissionState(missionState);
+
+        teamScoreUpdateUseCase.gainScoreOfArchive(mission, ScoreStatus.MINUS);
 
         return deleteArchive.getId();
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveQueryService.java
@@ -1,5 +1,6 @@
 package com.moing.backend.domain.missionArchive.domain.service;
 
+import com.moing.backend.domain.member.domain.repository.MemberRepository;
 import com.moing.backend.domain.mission.application.dto.res.FinishMissionBoardRes;
 import com.moing.backend.domain.mission.application.dto.res.RepeatMissionBoardRes;
 import com.moing.backend.domain.mission.application.dto.res.SingleMissionBoardRes;
@@ -26,6 +27,7 @@ public class MissionArchiveQueryService {
     private final MissionRepository missionRepository;
     private final MissionArchiveRepository missionArchiveRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
 
     public MissionArchive findByMissionArchiveId(Long missionArchiveId) {
         return missionArchiveRepository.findById(missionArchiveId).orElseThrow(NotFoundMissionArchiveException::new);
@@ -42,15 +44,11 @@ public class MissionArchiveQueryService {
             return optional.get();
         }
     }
-    public List<MissionArchive> findOneMyArchive(Long memberId, Long missionId, Long count) {
+    public MissionArchive findOneMyArchive(Long memberId, Long missionId, Long count) {
 
-        Optional<List<MissionArchive>> optional = missionArchiveRepository.findMyArchives(memberId, missionId);
+        List<MissionArchive> missionArchives = missionArchiveRepository.findMyArchives(memberId, missionId).orElseThrow(NotFoundMissionArchiveException::new);
+        return missionArchives.stream().filter( m -> m.getCount().equals(count)).findFirst().orElseThrow(NotFoundMissionArchiveException::new);
 
-        if (optional.isPresent() && optional.get().size() == 0) {
-            return new ArrayList<>();
-        } else {
-            return optional.get();
-        }
     }
 
     public List<MissionArchive> findOthersArchive(Long memberId, Long missionId) {

--- a/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreUpdateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreUpdateUseCase.java
@@ -38,7 +38,6 @@ public class TeamScoreUpdateUseCase {
         Long gainScore = calculateScoreByArchive(numOfMember);
 
         teamScore.updateScore(gainScore * scoreStatus.getValue());
-        teamScore.updateLevel();
 
     }
 
@@ -69,7 +68,6 @@ public class TeamScoreUpdateUseCase {
         } else {
             teamScore.updateScore(BONUS_SCORE_REPEAT_MISSION);
         }
-        teamScore.updateLevel();
 
     }
 

--- a/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreUpdateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreUpdateUseCase.java
@@ -5,6 +5,7 @@ import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
 import com.moing.backend.domain.mission.domain.service.MissionQueryService;
 import com.moing.backend.domain.team.domain.entity.Team;
+import com.moing.backend.domain.teamScore.domain.entity.ScoreStatus;
 import com.moing.backend.domain.teamScore.domain.entity.TeamScore;
 import com.moing.backend.domain.teamScore.domain.service.TeamScoreQueryService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class TeamScoreUpdateUseCase {
     /**
      * 매번 미션 인증 시 점수 적립
      */
-    public void gainScoreOfArchive(Mission mission) {
+    public void gainScoreOfArchive(Mission mission, ScoreStatus scoreStatus) {
 
 
         Team team = mission.getTeam();
@@ -36,7 +37,7 @@ public class TeamScoreUpdateUseCase {
         Integer numOfMember = team.getNumOfMember();
         Long gainScore = calculateScoreByArchive(numOfMember);
 
-        teamScore.updateScore(gainScore);
+        teamScore.updateScore(gainScore * scoreStatus.getValue());
         teamScore.updateLevel();
 
     }

--- a/src/main/java/com/moing/backend/domain/teamScore/domain/entity/ScoreStatus.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/domain/entity/ScoreStatus.java
@@ -1,0 +1,11 @@
+package com.moing.backend.domain.teamScore.domain.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ScoreStatus {
+    PLUS(1L), MINUS(-1L);
+    private final Long value;
+}

--- a/src/main/java/com/moing/backend/domain/teamScore/domain/entity/TeamScore.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/domain/entity/TeamScore.java
@@ -34,17 +34,51 @@ public class TeamScore extends BaseTimeEntity {
     }
 
     public void updateScore(Long score) {
+
+        int newStep = getStep(this.level, this.score + score);
+
         this.score += score;
+
+        if (this.score < 0) { // 점수 차감 / score down + level down
+            this.updateLevel(ScoreStatus.MINUS);
+        }
+        else { // 점수 획득. score up /  score down + level up
+
+            if ((40 + (newStep * 15L) <= this.score)) { // score down + level up
+                this.updateLevel(ScoreStatus.PLUS);
+
+            } else { //  score up
+//                this.score += score;
+            }
+        }
+
+
     }
 
-    public void updateLevel() {
-        final int[] steps = {1, 2, 25, 45, 70, 120};
+    public int getStep(Long level, Long score) {
+        final int[] steps = {1, 2, 26, 46, 71, 121};
+
+        int index = 0;
+        for (int i = 5; i > 0; i--) {
+            if (steps[i-1] <= this.level && this.level < steps[i]) {
+                index=i-1;
+                break;
+
+            }
+        }
+        return index;
+
+    }
+
+    public void updateLevel(ScoreStatus sign) {
+        final int[] steps = {1, 2, 26, 46, 71, 121};
+
+        this.level += sign.getValue();
 
         for (int i = 5; i > 0; i--) {
             if (steps[i-1] <= this.level && this.level <= steps[i]) {
-                if ((40 + ((i-1) * 15)) <= score) {
-                    this.level+=1;
-                    this.score -= (40 + ((i-1) * 15));
+                if ((40 + ((i-1) * 20)) <= score || score < 0) {
+                    this.score -= sign.getValue() * (40 + ((i-1) * 20));
                     this.team.updateLevelOfFire();
                     return;
                 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
미션 인증 취소 (다시 인증하기) 시, 올라간 불꽃이 줄어들어야 해요

## 변경 사항
- TeamScore 내 스코어 로직 변경
- 미션 인증 삭제 위한 메소드에서 해당하는 인증 엔티티 찾는 로직 변경 → 미션 인증 취소 버그 해결?
- 미션 인증 취소하기 로직에 스코어 차감 추가
  - 점수 차감시 레벨 다운 로직 추가
  - 레벨에 따른 레벨업 기준 점수 변경 로직 변경 

## 코드 리뷰 시 참고 사항

## 테스트 결과
