### PR TITLE
MNG-16 fix : 미션 건너뛰기 취소 안되는 버그 해결

### DIFF
--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveDeleteUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveDeleteUseCase.java
@@ -12,6 +12,7 @@ import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiv
 import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.missionArchive.application.mapper.MissionArchiveMapper;
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
+import com.moing.backend.domain.missionArchive.domain.entity.MissionArchiveStatus;
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveDeleteService;
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveSaveService;
@@ -74,7 +75,7 @@ public class MissionArchiveDeleteUseCase {
             throw new NoAccessMissionArchiveException();
         }
 
-        if (mission.getWay().equals(MissionWay.PHOTO)) {
+        if (deleteArchive.getStatus().equals(MissionArchiveStatus.COMPLETE) && mission.getWay().equals(MissionWay.PHOTO)) {
             String archive = deleteArchive.getArchive();
             updateUtils.deleteImgUrl(archive);
         }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
미션 건너뛰기 취소 안되는 버그 해결

## 변경 사항
예외처리를 잘하자!

## 코드 리뷰 시 참고 사항
애증의 조건문 남겨드립니다 .. 
        if (deleteArchive.getStatus().equals(MissionArchiveStatus.COMPLETE) && mission.getWay().equals(MissionWay.PHOTO)) {

## 테스트 결과
