### PR TITLE
hotfix : 레벨 70 이상 목표보드 에러

### DIFF
--- a/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreGetUseCase.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreGetUseCase.java
@@ -27,11 +27,19 @@ public class TeamScoreGetUseCase {
     public TeamScoreRes getTeamScoreInfo(Long teamId) {
 
         TeamScore teamScore = teamScoreQueryService.findTeamScoreByTeam(teamId);
+        Long level = teamScore.getLevel();
+        Long score = teamScore.getScore();
+
+        // 70 레벨 이상은 경험치 120 되어야 레벨업 가능. level을 각 레벨 별 필요한 경험치 수에 따르 퍼센트로 계산
+        if (level > 70) {
+            score = ( score / 120 ) * 100;
+        }
+
         return TeamScoreRes.builder()
-                .score(teamScore.getScore())
-                .level(teamScore.getLevel())
-                .build()
-        ;
+                .score(score)
+                .level(level)
+                .build();
+
     }
 
 }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
 레벨 70 이상 일 때 score가 100 넘기에 레벨 70 이상 조정
 
## 변경 사항

## 코드 리뷰 시 참고 사항

## 테스트 결과
