### PR TITLE
MNG-21 : 미션 인증 시 문구 추가

### DIFF
--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/req/MissionArchiveReq.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/req/MissionArchiveReq.java
@@ -2,6 +2,7 @@ package com.moing.backend.domain.missionArchive.application.dto.req;
 
 import lombok.*;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Size;
 
 @Builder
@@ -10,12 +11,16 @@ import javax.validation.constraints.Size;
 public class MissionArchiveReq {
 
     private String status;
+
     @Size(min = 1, max = 1000)
     private String archive; //사진일 경우 파일명, 이외에는 text,link
 
+    private String contents;
+
     @Builder
-    public MissionArchiveReq(String status, String archive) {
+    public MissionArchiveReq(String status, String archive, String contents) {
         this.status = status;
         this.archive = archive;
+        this.contents = contents;
     }
 }

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchiveRes.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/MissionArchiveRes.java
@@ -18,6 +18,7 @@ public class MissionArchiveRes {
     private Long count;
     private String heartStatus;
     private Long hearts;
+    private String contents;
 
     public void updateCount(Long count) {
         this.count = count;

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/PersonalArchiveRes.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/dto/res/PersonalArchiveRes.java
@@ -2,6 +2,8 @@ package com.moing.backend.domain.missionArchive.application.dto.res;
 
 import lombok.*;
 
+import javax.annotation.Nullable;
+
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor
@@ -23,6 +25,9 @@ public class PersonalArchiveRes {
     private Long count;
 
     private Long makerId;
+
+    @Nullable
+    private String contents;
 
 
 }

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/mapper/MissionArchiveMapper.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/mapper/MissionArchiveMapper.java
@@ -2,7 +2,6 @@ package com.moing.backend.domain.missionArchive.application.mapper;
 
 import com.moing.backend.domain.member.domain.entity.Member;
 import com.moing.backend.domain.mission.application.dto.res.FinishMissionBoardRes;
-import com.moing.backend.domain.mission.application.dto.res.RepeatMissionBoardRes;
 import com.moing.backend.domain.mission.application.dto.res.SingleMissionBoardRes;
 import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
@@ -29,6 +28,7 @@ public class MissionArchiveMapper {
                 .member(member)
                 .mission(mission)
                 .heartList(new ArrayList<>())
+                .contents(missionArchiveReq.getContents())
                 .build();
     }
 
@@ -50,6 +50,7 @@ public class MissionArchiveMapper {
                         .filter(heart -> heart.getHeartStatus() == ( MissionHeartStatus.True))
                         .filter(heart -> heart.getMissionArchive().equals( missionArchive))// heartStatus가 true인 요소만 필터링
                         .count())
+                .contents(missionArchive.getContents())
                 .build();
     }
 
@@ -84,6 +85,7 @@ public class MissionArchiveMapper {
                         .filter(heart -> heart.getMissionArchive().equals( missionArchive))// heartStatus가 true인 요소만 필터링
                         .count())
                 .makerId(missionArchive.getMember().getMemberId())
+                .contents(missionArchive.getContents())
                 .build();
     }
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/entity/MissionArchive.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/entity/MissionArchive.java
@@ -39,11 +39,13 @@ public class MissionArchive extends BaseTimeEntity { // 1회 미션을 저장 �
     @Enumerated(value = EnumType.STRING)
     private MissionArchiveStatus status;
 
-
     @Column(nullable = false, columnDefinition="TEXT", length = 4000)
     private String archive; //링크, 글, 사진 뭐든 가능
 
     private Long count; // 횟수
+
+    @Column(nullable = true, columnDefinition="TEXT", length = 1000)
+    private String contents;
 
     @OneToMany(mappedBy = "missionArchive", cascade = CascadeType.REMOVE)
     private List<MissionHeart> heartList = new ArrayList<>();

--- a/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreGetUseCase.java
+++ b/src/main/java/com/moing/backend/domain/teamScore/application/service/TeamScoreGetUseCase.java
@@ -27,11 +27,19 @@ public class TeamScoreGetUseCase {
     public TeamScoreRes getTeamScoreInfo(Long teamId) {
 
         TeamScore teamScore = teamScoreQueryService.findTeamScoreByTeam(teamId);
+        Long level = teamScore.getLevel();
+        Long score = teamScore.getScore();
+
+        // 70 레벨 이상은 경험치 120 되어야 레벨업 가능. level을 각 레벨 별 필요한 경험치 수에 따르 퍼센트로 계산
+        if (level > 70) {
+            score = ( score / 120 ) * 100;
+        }
+
         return TeamScoreRes.builder()
-                .score(teamScore.getScore())
-                .level(teamScore.getLevel())
-                .build()
-        ;
+                .score(score)
+                .level(level)
+                .build();
+
     }
 
 }

--- a/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionArchiveControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionArchiveControllerTest.java
@@ -1,7 +1,6 @@
 package com.moing.backend.domain.missionArchive.representation;
 
 import com.moing.backend.config.CommonControllerTest;
-import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveHeartReq;
 import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
 import com.moing.backend.domain.missionArchive.application.dto.res.*;
 import com.moing.backend.domain.missionArchive.application.service.*;
@@ -65,6 +64,7 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                 .count(1L)
                 .heartStatus("[True/False]")
                 .hearts(1L)
+                .contents("contents")
                 .build();
 
         given(missionArchiveCreateUseCase.createArchive(any(),any(),any())).willReturn(output);
@@ -93,7 +93,10 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                                 ),
                                 requestFields(
                                         fieldWithPath("status").description("미션 인증 상태 [COMPLETE/SKIP]"),
-                                        fieldWithPath("archive").description("미션 인증물 [s3URL/text/링크] ")
+                                        fieldWithPath("archive").description("미션 인증물 [s3URL/text/링크] "),
+                                        fieldWithPath("contents").description("미션 인증 문구 [null 허용] ")
+
+
                                 ),
                                 responseFields(
                                         fieldWithPath("isSuccess").description("true"),
@@ -105,7 +108,8 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.status").description("미션 인증 상태"),
                                         fieldWithPath("data.count").description("미션 인증 횟수"),
                                         fieldWithPath("data.hearts").description("미션 인증 좋아요 수"),
-                                        fieldWithPath("data.heartStatus").description("미션 인증 좋아요 상태")
+                                        fieldWithPath("data.heartStatus").description("미션 인증 좋아요 상태"),
+                                        fieldWithPath("data.contents").description("미션 인증 문구")
                                 )
                         )
                 )
@@ -132,6 +136,7 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                 .count(1L)
                 .heartStatus("[True/False]")
                 .hearts(1L)
+                .contents("contents")
                 .build();
 
         given(missionArchiveUpdateUseCase.updateArchive(any(),any(),any())).willReturn(output);
@@ -160,7 +165,9 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                                 ),
                                 requestFields(
                                         fieldWithPath("status").description("미션 인증 상태 [COMPLETE/SKIP]"),
-                                        fieldWithPath("archive").description("미션 인증물 [s3URL/text/링크] ")
+                                        fieldWithPath("archive").description("미션 인증물 [s3URL/text/링크] "),
+                                        fieldWithPath("contents").description("미션 인증 문구 [null 허용] ")
+
                                 ),
                                 responseFields(
                                         fieldWithPath("isSuccess").description("true"),
@@ -173,7 +180,9 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.status").description("미션 인증 상태"),
                                         fieldWithPath("data.count").description("미션 인증 횟수"),
                                         fieldWithPath("data.heartStatus").description("미션 인증 좋아요 상태"),
-                                        fieldWithPath("data.hearts").description("미션 인증 좋아요 수")
+                                        fieldWithPath("data.hearts").description("미션 인증 좋아요 수"),
+                                        fieldWithPath("data.contents").description("미션 인증 문구")
+
                                 )
                         )
                 )
@@ -236,6 +245,7 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                 .count(1L)
                 .heartStatus("[True/False]")
                 .hearts(1L)
+                .contents("contents")
                 .build());
 
         MyMissionArchiveRes output = MyMissionArchiveRes.builder()
@@ -278,7 +288,8 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                                         fieldWithPath("data.archives[].status").description("미션 인증 상태"),
                                         fieldWithPath("data.archives[].count").description("미션 인증 횟수"),
                                         fieldWithPath("data.archives[].heartStatus").description("미션 인증 좋아요 상태"),
-                                        fieldWithPath("data.archives[].hearts").description("미션 인증 좋아요 수")
+                                        fieldWithPath("data.archives[].hearts").description("미션 인증 좋아요 수"),
+                                        fieldWithPath("data.archives[].contents").description("미션 인증 문구")
 
 
                                         )
@@ -304,6 +315,7 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                 .heartStatus("[True/False]")
                 .hearts(3)
                 .makerId(1L)
+                .contents("contents")
                 .build());
 
         given(missionArchiveReadUseCase.getPersonalArchive(any(),any())).willReturn(output);
@@ -343,10 +355,11 @@ public class MissionArchiveControllerTest extends CommonControllerTest {
                                         fieldWithPath("data[].count").description("미션 인증 횟수"),
                                         fieldWithPath("data[].heartStatus").description("미션 인증 좋아요 상태 "),
                                         fieldWithPath("data[].hearts").description("미션 인증 좋아요 수 "),
-                                        fieldWithPath("data[].makerId").description("미션 인증한 사람 ")
+                                        fieldWithPath("data[].makerId").description("미션 인증한 사람 "),
+                                        fieldWithPath("data[].contents").description("미션 인증 문구")
 
 
-                                        )
+                                )
                         )
                 )
                 .andReturn();


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 미션 인증 시 문구 추가 

## 변경 사항
- MissionArchive 에 contents 칼럼 추가
  - nullable 설정
- 관련 dto,mapper에 관련 칼럼 추가

## 코드 리뷰 시 참고 사항
- 엔티티 변경사항 있으니 업데이트 반영 시 고려해야할 것 같아요.
- 미션 인증 댓글 기능과 관련해 엔티티 부분에서 충돌 사항 생길 수 있으니 주의 해야할 것 같아요!
 
## 테스트 결과
