### PR TITLE
MNG-22 : 반복미션 모아보기 인증 인원수 리턴 타입 변경

### DIFF
--- a/src/main/java/com/moing/backend/domain/mission/application/dto/res/GatherSingleMissionRes.java
+++ b/src/main/java/com/moing/backend/domain/mission/application/dto/res/GatherSingleMissionRes.java
@@ -16,10 +16,10 @@ public class GatherSingleMissionRes {
     private String missionTitle;
     private String dueTo;
     private String status;
-    private Long done;
-    private Long total;
+    private String done;
+    private String total;
 
-    public GatherSingleMissionRes(Long missionId, Long teamId, String teamName, String missionTitle, String dueTo, String status, Long total) {
+    public GatherSingleMissionRes(Long missionId, Long teamId, String teamName, String missionTitle, String dueTo, String status, String total) {
         this.missionId = missionId;
         this.teamId = teamId;
         this.teamName = teamName;

--- a/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepositoryImpl.java
@@ -192,7 +192,7 @@ public class MissionCustomRepositoryImpl implements MissionCustomRepository{
                         missionArchive.status.coalesce(mission.status).stringValue(),
 
                         JPAExpressions
-                                .select(missionArchive.member.count().longValue())
+                                .select(missionArchive.member.count().stringValue())
                                 .from(missionArchive)
                                 .where(
                                         missionArchive.mission.id.eq(mission.id),

--- a/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionGatherControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/missionArchive/representation/MissionGatherControllerTest.java
@@ -43,8 +43,8 @@ public class MissionGatherControllerTest extends CommonControllerTest {
                 .teamName("team name")
                 .missionTitle("mission title")
                 .status("WAIT/ONGOING/SKIP/COMPLETE")
-                .done(0L)
-                .total(5L)
+                .done("0")
+                .total("5")
                 .build());
 
         given(missionGatherBoardUseCase.getAllActiveSingleMissions(any())).willReturn(output);
@@ -152,8 +152,8 @@ public class MissionGatherControllerTest extends CommonControllerTest {
                 .teamName("team name")
                 .missionTitle("mission title")
                 .status("WAIT/ONGOING/SKIP/COMPLETE")
-                .done(0L)
-                .total(5L)
+                .done("0")
+                .total("5")
                 .build());
 
         given(missionGatherBoardUseCase.getTeamActiveSingleMissions(any(),any())).willReturn(output);


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
반복미션 모아보기 인증 인원수 리턴 타입 변경

## 변경 사항
클라 요청대로 인원수 리턴타입 변경하였습니다!

## 코드 리뷰 시 참고 사항

## 테스트 결과
