### PR TITLE
[MNG-21] hotfix : 미션 재인증(삭제) 시 500에러 해결

### DIFF
--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveDeleteUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/MissionArchiveDeleteUseCase.java
@@ -12,6 +12,7 @@ import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveDele
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
 import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveSaveService;
 import com.moing.backend.domain.missionArchive.exception.NoAccessMissionArchiveException;
+import com.moing.backend.domain.missionComment.domain.service.MissionCommentDeleteService;
 import com.moing.backend.domain.missionHeart.domain.service.MissionHeartQueryService;
 import com.moing.backend.domain.team.domain.entity.Team;
 import com.moing.backend.domain.teamScore.application.service.TeamScoreUpdateUseCase;
@@ -31,6 +32,7 @@ public class MissionArchiveDeleteUseCase {
     private final MissionArchiveQueryService missionArchiveQueryService;
     private final MissionArchiveDeleteService missionArchiveDeleteService;
     private final MissionQueryService missionQueryService;
+    private final MissionCommentDeleteService missionCommentDeleteService;
 
     private final MemberGetService memberGetService;
     private final TeamScoreUpdateUseCase teamScoreUpdateUseCase;
@@ -61,6 +63,7 @@ public class MissionArchiveDeleteUseCase {
             updateUtils.deleteImgUrl(archive);
         }
 
+        missionCommentDeleteService.deleteAllCommentByMissionArchive(deleteArchive.getId());
         missionArchiveDeleteService.deleteMissionArchive(deleteArchive);
         teamScoreUpdateUseCase.gainScoreOfArchive(mission, ScoreStatus.MINUS);
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveDeleteService.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/service/MissionArchiveDeleteService.java
@@ -2,6 +2,7 @@ package com.moing.backend.domain.missionArchive.domain.service;
 
 import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
 import com.moing.backend.domain.missionArchive.domain.repository.MissionArchiveRepository;
+import com.moing.backend.domain.missionComment.domain.service.MissionCommentDeleteService;
 import com.moing.backend.global.annotation.DomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/moing/backend/domain/missionComment/domain/repository/MissionCommentRepository.java
+++ b/src/main/java/com/moing/backend/domain/missionComment/domain/repository/MissionCommentRepository.java
@@ -3,10 +3,13 @@ package com.moing.backend.domain.missionComment.domain.repository;
 import com.moing.backend.domain.missionComment.domain.entity.MissionComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MissionCommentRepository extends JpaRepository<MissionComment, Long>, MissionCommentCustomRepository {
 
     Optional<MissionComment> findMissionCommentByMissionCommentId(Long missionCommentId);
+
+    void deleteAllMissionCommentsByMissionArchiveId(Long missionArchiveId);
 
 }

--- a/src/main/java/com/moing/backend/domain/missionComment/domain/service/MissionCommentDeleteService.java
+++ b/src/main/java/com/moing/backend/domain/missionComment/domain/service/MissionCommentDeleteService.java
@@ -15,4 +15,8 @@ public class MissionCommentDeleteService implements CommentDeleteService<Mission
     public void deleteComment(MissionComment comment) {
         missionCommentRepository.delete(comment);
     }
+
+    public void deleteAllCommentByMissionArchive(Long missionArchiveId) {
+        missionCommentRepository.deleteAllMissionCommentsByMissionArchiveId(missionArchiveId);
+    }
 }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
 미션 재인증(삭제) 시 연관관계에 있는 missionComment 삭제 로직 추가
 
## 변경 사항
- MissionArchive DB 삭제하려고 하던중 연관관계에 있는 MissionComments 가 있어 삭제할 수 없다는 에러를 발견하였습니다.
- missionArchive 가 같은 missionComment 들을 모두 삭제하는 datajpa 메소드를 추가하고 이를 사용한 로직을 추가하였습니다.

## 코드 리뷰 시 참고 사항
https://github.com/Modagbul/MOING_Server_Release/blob/2f41dc7a6e82380c906f963e3d45362b496ac9dc/src/main/java/com/moing/backend/domain/missionComment/domain/service/MissionCommentDeleteService.java#L19-L21
https://github.com/Modagbul/MOING_Server_Release/blob/2f41dc7a6e82380c906f963e3d45362b496ac9dc/src/main/java/com/moing/backend/domain/missionComment/domain/repository/MissionCommentRepository.java#L13

## 테스트 결과
