### PR TITLE
MNG-22 fix : 한번미션 정렬 기준 변경

### DIFF
--- a/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepositoryImpl.java
+++ b/src/main/java/com/moing/backend/domain/mission/domain/repository/MissionCustomRepositoryImpl.java
@@ -8,9 +8,12 @@ import com.moing.backend.domain.mission.domain.entity.Mission;
 import com.moing.backend.domain.mission.domain.entity.QMission;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionStatus;
 import com.moing.backend.domain.mission.domain.entity.constant.MissionType;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -211,9 +214,11 @@ public class MissionCustomRepositoryImpl implements MissionCustomRepository{
                         mission.status.eq(MissionStatus.ONGOING).or(mission.status.eq(MissionStatus.WAIT)),
                         mission.type.eq(MissionType.ONCE)
                 )
-                .orderBy(mission.dueTo.asc())
+                .orderBy(missionArchive.status.asc(),mission.dueTo.asc(),missionArchive.createdDate.desc())
                 .fetch());
     }
+
+
 
     public boolean findRepeatMissionsByTeamId(Long teamId) {
         return queryFactory


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
1차 QA 중 한번 미션 블록 정렬 규척이 적용되어 있지 않아요. 적용

## 변경 사항
진행중 미션-한번미션 조회 쿼리 중 정렬 조건을 추가하였습니다.

## 코드 리뷰 시 참고 사항

## 테스트 결과
