### PR TITLE
refactor : 신고하기 기능 전략패턴 적용

### DIFF
--- a/src/main/java/com/moing/backend/domain/board/domain/entity/Board.java
+++ b/src/main/java/com/moing/backend/domain/board/domain/entity/Board.java
@@ -79,4 +79,8 @@ public class Board extends BaseTimeEntity {
     public void updateTeam(Team team) {
         this.team = team;
     }
+
+    public String getWriterNickName() {
+        return teamMember.getMemberNickName();
+    }
 }

--- a/src/main/java/com/moing/backend/domain/boardComment/domain/entity/BoardComment.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/domain/entity/BoardComment.java
@@ -46,4 +46,8 @@ public class BoardComment extends Comment {
         this.content=content;
         this.isLeader=isLeader;
     }
+
+    public String getWriterNickName(){
+        return teamMember.getMemberNickName();
+    }
 }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/entity/MissionArchive.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/entity/MissionArchive.java
@@ -57,6 +57,10 @@ public class MissionArchive extends BaseTimeEntity { // 1회 미션을 저장 �
         this.status = MissionArchiveStatus.valueOf(missionArchiveReq.getStatus());
     }
 
+    public void updateArchive(String archive) {
+        this.archive = archive;
+    }
+
     public void updateCount(Long count) {
         this.count = count;
     }

--- a/src/main/java/com/moing/backend/domain/missionArchive/domain/entity/MissionArchive.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/domain/entity/MissionArchive.java
@@ -70,4 +70,7 @@ public class MissionArchive extends BaseTimeEntity { // 1회 미션을 저장 �
     }
 
 
+    public String getWriterNickName(){
+        return member.getNickName();
+    }
 }

--- a/src/main/java/com/moing/backend/domain/missionComment/domain/entity/MissionComment.java
+++ b/src/main/java/com/moing/backend/domain/missionComment/domain/entity/MissionComment.java
@@ -45,4 +45,8 @@ public class MissionComment extends Comment {
         this.content=content;
         this.isLeader=isLeader;
     }
+
+    public String getWriterNickName(){
+        return teamMember.getMemberNickName();
+    }
 }

--- a/src/main/java/com/moing/backend/domain/report/application/service/BoardCommentReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/BoardCommentReportStrategy.java
@@ -1,0 +1,30 @@
+package com.moing.backend.domain.report.application.service;
+
+import com.moing.backend.domain.boardComment.domain.entity.BoardComment;
+import com.moing.backend.domain.boardComment.domain.service.BoardCommentGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.moing.backend.domain.report.presentation.constant.ReportResponseMessage.REPORT_MESSAGE;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BoardCommentReportStrategy implements ReportStrategy {
+
+
+    private final BoardCommentGetService boardCommentGetService;
+
+
+    @Override
+    public String processReport(Long targetId) {
+        BoardComment boardComment = boardCommentGetService.getComment(targetId);
+        boardComment.updateContent(REPORT_MESSAGE.getMessage());
+        return getTargetMemberNickName(boardComment);
+    }
+
+    private String getTargetMemberNickName(BoardComment boardComment){
+        return boardComment.getWriterNickName();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/report/application/service/BoardReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/BoardReportStrategy.java
@@ -1,0 +1,33 @@
+package com.moing.backend.domain.report.application.service;
+
+import com.moing.backend.domain.board.application.dto.request.UpdateBoardRequest;
+import com.moing.backend.domain.board.domain.entity.Board;
+import com.moing.backend.domain.board.domain.service.BoardGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.moing.backend.domain.report.presentation.constant.ReportResponseMessage.REPORT_MESSAGE;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BoardReportStrategy implements ReportStrategy {
+
+    private final BoardGetService boardGetService;
+
+    @Override
+    public String processReport(Long targetId) {
+        Board board = boardGetService.getBoard(targetId);
+        board.updateBoard(UpdateBoardRequest.builder()
+                .title(REPORT_MESSAGE.getMessage())
+                .content(REPORT_MESSAGE.getMessage())
+                .isNotice(board.isNotice())
+                .build());
+        return getTargetMemberNickName(board);
+    }
+
+    private String getTargetMemberNickName(Board board){
+        return board.getWriterNickName();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
@@ -28,15 +28,10 @@ public class MissionArchiveReportStrategy implements ReportStrategy {
         Mission mission = missionArchive.getMission();
 
         if (mission.getWay().equals(MissionWay.PHOTO) && missionArchive.getStatus().equals(MissionArchiveStatus.COMPLETE)) {
-            missionArchive.updateArchive(MissionArchiveReq.builder()
-                    .archive(REPORT_PHOTO.getMessage())
-                    .status(missionArchive.getStatus().name())
-                    .build());
+            missionArchive.updateArchive(REPORT_PHOTO.getMessage());
+
         } else {
-            missionArchive.updateArchive(MissionArchiveReq.builder()
-                    .archive(REPORT_MESSAGE.getMessage())
-                    .status(missionArchive.getStatus().name())
-                    .build());
+            missionArchive.updateArchive(REPORT_MESSAGE.getMessage());
 
         }
 

--- a/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
@@ -1,0 +1,50 @@
+package com.moing.backend.domain.report.application.service;
+
+import com.moing.backend.domain.mission.domain.entity.Mission;
+import com.moing.backend.domain.mission.domain.entity.constant.MissionWay;
+import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
+import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
+import com.moing.backend.domain.missionArchive.domain.entity.MissionArchiveStatus;
+import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.moing.backend.domain.report.presentation.constant.ReportResponseMessage.REPORT_MESSAGE;
+import static com.moing.backend.domain.report.presentation.constant.ReportResponseMessage.REPORT_PHOTO;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MissionArchiveReportStrategy implements ReportStrategy {
+
+
+    private final MissionArchiveQueryService missionArchiveQueryService;
+
+
+    @Override
+    public String processReport(Long targetId) {
+        MissionArchive missionArchive = missionArchiveQueryService.findByMissionArchiveId(targetId);
+        Mission mission = missionArchive.getMission();
+
+        if (mission.getWay().equals(MissionWay.PHOTO) && missionArchive.getStatus().equals(MissionArchiveStatus.COMPLETE)) {
+            missionArchive.updateArchive(MissionArchiveReq.builder()
+                    .archive(REPORT_PHOTO.getMessage())
+                    .status(missionArchive.getStatus().name())
+                    .build());
+        } else {
+            missionArchive.updateArchive(MissionArchiveReq.builder()
+                    .archive(REPORT_MESSAGE.getMessage())
+                    .status(missionArchive.getStatus().name())
+                    .build());
+
+        }
+
+        return getTargetMemberNickName(missionArchive);
+    }
+
+    private String getTargetMemberNickName(MissionArchive missionArchive){
+        return missionArchive.getWriterNickName();
+    }
+
+}

--- a/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
@@ -26,7 +26,7 @@ public class MissionArchiveReportStrategy implements ReportStrategy {
     public String processReport(Long targetId) {
         MissionArchive missionArchive = missionArchiveQueryService.findByMissionArchiveId(targetId);
 
-        if (isCompletePhotoMission(missionArchive)) {
+        if (isCompletedPhotoArchive(missionArchive)) {
             missionArchive.updateArchive(REPORT_PHOTO.getMessage());
         } else {
             missionArchive.updateArchive(REPORT_MESSAGE.getMessage());
@@ -39,7 +39,7 @@ public class MissionArchiveReportStrategy implements ReportStrategy {
         return missionArchive.getWriterNickName();
     }
 
-    private Boolean isCompletePhotoMission(MissionArchive archive) {
+    private Boolean isCompletedPhotoArchive (MissionArchive archive) {
         return archive.getMission().getWay().equals(MissionWay.PHOTO) && archive.getStatus().equals(MissionArchiveStatus.COMPLETE);
     }
 }

--- a/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java
@@ -25,14 +25,11 @@ public class MissionArchiveReportStrategy implements ReportStrategy {
     @Override
     public String processReport(Long targetId) {
         MissionArchive missionArchive = missionArchiveQueryService.findByMissionArchiveId(targetId);
-        Mission mission = missionArchive.getMission();
 
-        if (mission.getWay().equals(MissionWay.PHOTO) && missionArchive.getStatus().equals(MissionArchiveStatus.COMPLETE)) {
+        if (isCompletePhotoMission(missionArchive)) {
             missionArchive.updateArchive(REPORT_PHOTO.getMessage());
-
         } else {
             missionArchive.updateArchive(REPORT_MESSAGE.getMessage());
-
         }
 
         return getTargetMemberNickName(missionArchive);
@@ -42,4 +39,7 @@ public class MissionArchiveReportStrategy implements ReportStrategy {
         return missionArchive.getWriterNickName();
     }
 
+    private Boolean isCompletePhotoMission(MissionArchive archive) {
+        return archive.getMission().getWay().equals(MissionWay.PHOTO) && archive.getStatus().equals(MissionArchiveStatus.COMPLETE);
+    }
 }

--- a/src/main/java/com/moing/backend/domain/report/application/service/MissionCommentReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/MissionCommentReportStrategy.java
@@ -1,0 +1,31 @@
+package com.moing.backend.domain.report.application.service;
+
+import com.moing.backend.domain.missionComment.domain.entity.MissionComment;
+import com.moing.backend.domain.missionComment.domain.service.MissionCommentGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.moing.backend.domain.report.presentation.constant.ReportResponseMessage.REPORT_MESSAGE;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MissionCommentReportStrategy implements ReportStrategy {
+
+
+    private final MissionCommentGetService missionCommentGetService;
+
+
+    @Override
+    public String processReport(Long targetId) {
+        MissionComment missionComment=missionCommentGetService.getComment(targetId);
+        missionComment.updateContent(REPORT_MESSAGE.getMessage());
+
+        return getTargetMemberNickName(missionComment);
+    }
+
+    private String getTargetMemberNickName(MissionComment missionComment){
+        return missionComment.getWriterNickName();
+    }
+}

--- a/src/main/java/com/moing/backend/domain/report/application/service/ReportCreateUseCase.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/ReportCreateUseCase.java
@@ -1,26 +1,15 @@
 package com.moing.backend.domain.report.application.service;
 
-import com.moing.backend.domain.board.application.dto.request.UpdateBoardRequest;
-import com.moing.backend.domain.board.domain.entity.Board;
-import com.moing.backend.domain.board.domain.service.BoardGetService;
-import com.moing.backend.domain.boardComment.domain.entity.BoardComment;
-import com.moing.backend.domain.boardComment.domain.service.BoardCommentGetService;
 import com.moing.backend.domain.member.domain.service.MemberGetService;
-import com.moing.backend.domain.mission.domain.entity.Mission;
-import com.moing.backend.domain.mission.domain.entity.constant.MissionWay;
-import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
-import com.moing.backend.domain.missionArchive.domain.entity.MissionArchive;
-import com.moing.backend.domain.missionArchive.domain.entity.MissionArchiveStatus;
-import com.moing.backend.domain.missionArchive.domain.service.MissionArchiveQueryService;
-import com.moing.backend.domain.missionComment.domain.entity.MissionComment;
-import com.moing.backend.domain.missionComment.domain.service.MissionCommentGetService;
 import com.moing.backend.domain.report.application.mapper.ReportMapper;
 import com.moing.backend.domain.report.domain.entity.Report;
-import com.moing.backend.domain.report.domain.entity.constant.ReportType;
 import com.moing.backend.domain.report.domain.service.ReportSaveService;
+import com.moing.backend.domain.report.presentation.constant.StrategyCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Service
 @Transactional
@@ -28,68 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReportCreateUseCase {
 
     private final ReportSaveService reportSaveService;
+    private final Map<String, ReportStrategy> strategyMap;
     private final MemberGetService memberGetService;
 
-    private final BoardGetService boardGetService;
-    private final MissionArchiveQueryService missionArchiveQueryService;
-    private final BoardCommentGetService boardCommentGetService;
-    private final MissionCommentGetService missionCommentGetService;
-
-    private final String REPORT_BOARD_TITLE ="신고 접수된 게시물입니다.";
-    private final String REPORT_BOARD_MESSAGE ="신고 접수로 삭제된 게시물입니다.";
-    private final String REPORT_MISSION_MESSAGE ="신고 접수로 삭제된 인증입니다.";
-    private final String REPORT_MISSION_PHOTO ="https://modagbul.s3.ap-northeast-2.amazonaws.com/reportImage.png";
-
-
     public Long createReport(String socialId, Long targetId, String reportType) {
+        ReportStrategy strategy = strategyMap.get(StrategyCategory.valueOf(reportType).getStrategyName());
         Long memberId = memberGetService.getMemberBySocialId(socialId).getMemberId();
-        String targetMemberNickName = null ;
-
-        if (reportType.equals(ReportType.BOARD.name())) {
-            Board board = boardGetService.getBoard(targetId);
-
-            targetMemberNickName = board.getTeamMember().getMember().getNickName();
-
-            board.updateBoard(UpdateBoardRequest.builder()
-                    .title(REPORT_BOARD_TITLE)
-                    .content(REPORT_BOARD_MESSAGE)
-                    .isNotice(board.isNotice())
-                    .build());
-        }
-        else if (reportType.equals(ReportType.BCOMMENT.name())) {
-            BoardComment boardComment = boardCommentGetService.getComment(targetId);
-            targetMemberNickName = boardComment.getTeamMember().getMember().getNickName();
-            boardComment.updateContent(REPORT_BOARD_MESSAGE);
-
-        } else if(reportType.equals(ReportType.MCOMMENT.name())){
-            MissionComment missionComment=missionCommentGetService.getComment(targetId);
-            targetMemberNickName=missionComment.getTeamMember().getMember().getNickName();
-            missionComment.updateContent(REPORT_BOARD_MESSAGE);
-        }
-        else {
-
-            MissionArchive missionArchive = missionArchiveQueryService.findByMissionArchiveId(targetId);
-            Mission mission = missionArchive.getMission();
-
-            targetMemberNickName = missionArchive.getMember().getNickName();
-
-            if (mission.getWay().equals(MissionWay.PHOTO) && missionArchive.getStatus().equals(MissionArchiveStatus.COMPLETE)) {
-                missionArchive.updateArchive(MissionArchiveReq.builder()
-                        .archive(REPORT_MISSION_PHOTO)
-                        .status(missionArchive.getStatus().name())
-                        .build());
-            } else {
-                missionArchive.updateArchive(MissionArchiveReq.builder()
-                        .archive(REPORT_MISSION_MESSAGE)
-                        .status(missionArchive.getStatus().name())
-                        .build());
-
-            }
-
-        }
-
-        Report save = reportSaveService.save(ReportMapper.mapToReport(memberId, targetId, reportType,targetMemberNickName));
-
+        String targetMemberNickName= strategy.processReport(targetId);
+        Report save = reportSaveService.save(ReportMapper.mapToReport(memberId, targetId, reportType, targetMemberNickName));
         return save.getTargetId();
     }
 }

--- a/src/main/java/com/moing/backend/domain/report/application/service/ReportStrategy.java
+++ b/src/main/java/com/moing/backend/domain/report/application/service/ReportStrategy.java
@@ -1,0 +1,6 @@
+package com.moing.backend.domain.report.application.service;
+
+public interface ReportStrategy {
+    String processReport(Long targetId);
+
+}

--- a/src/main/java/com/moing/backend/domain/report/presentation/ReportController.java
+++ b/src/main/java/com/moing/backend/domain/report/presentation/ReportController.java
@@ -1,21 +1,20 @@
 package com.moing.backend.domain.report.presentation;
 
-import com.moing.backend.domain.missionArchive.application.dto.req.MissionArchiveReq;
-import com.moing.backend.domain.missionArchive.application.dto.res.MissionArchiveRes;
 import com.moing.backend.domain.report.application.service.ReportCreateUseCase;
-import com.moing.backend.domain.report.domain.entity.Report;
 import com.moing.backend.global.config.security.dto.User;
 import com.moing.backend.global.response.SuccessResponse;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import static com.moing.backend.domain.missionArchive.domain.constant.MissionArchiveResponseMessage.CREATE_ARCHIVE_SUCCESS;
 import static com.moing.backend.domain.report.presentation.constant.ReportResponseMessage.CREATE_REPORT_SUCCESS;
 
 @RestController
-@AllArgsConstructor
+@RequiredArgsConstructor
 @RequestMapping("/api/report")
 public class ReportController {
 

--- a/src/main/java/com/moing/backend/domain/report/presentation/ReportController.java
+++ b/src/main/java/com/moing/backend/domain/report/presentation/ReportController.java
@@ -3,7 +3,7 @@ package com.moing.backend.domain.report.presentation;
 import com.moing.backend.domain.report.application.service.ReportCreateUseCase;
 import com.moing.backend.global.config.security.dto.User;
 import com.moing.backend.global.response.SuccessResponse;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import static com.moing.backend.domain.report.presentation.constant.ReportResponseMessage.CREATE_REPORT_SUCCESS;
 
 @RestController
-@RequiredArgsConstructor
+@AllArgsConstructor
 @RequestMapping("/api/report")
 public class ReportController {
 

--- a/src/main/java/com/moing/backend/domain/report/presentation/constant/ReportResponseMessage.java
+++ b/src/main/java/com/moing/backend/domain/report/presentation/constant/ReportResponseMessage.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReportResponseMessage {
 
-    CREATE_REPORT_SUCCESS("게시글 신고를 완료 했습니다.");
+    CREATE_REPORT_SUCCESS("게시글 신고를 완료 했습니다."),
+    REPORT_MESSAGE("신고 접수로 삭제되었습니다."),
+    REPORT_PHOTO("https://modagbul.s3.ap-northeast-2.amazonaws.com/reportImage.png");
 
     private final String message;
 

--- a/src/main/java/com/moing/backend/domain/report/presentation/constant/StrategyCategory.java
+++ b/src/main/java/com/moing/backend/domain/report/presentation/constant/StrategyCategory.java
@@ -1,0 +1,16 @@
+package com.moing.backend.domain.report.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StrategyCategory {
+
+    BCOMMENT("boardCommentReportStrategy"),
+    BOARD("boardReportStrategy"),
+    MISSION("missionArchiveReportStrategy"),
+    MCOMMENT("missionCommentReportStrategy");
+
+    private final String strategyName;
+}

--- a/src/main/java/com/moing/backend/domain/teamMember/domain/entity/TeamMember.java
+++ b/src/main/java/com/moing/backend/domain/teamMember/domain/entity/TeamMember.java
@@ -48,4 +48,8 @@ public class TeamMember extends BaseTimeEntity {
         this.isDeleted = true;
         team.deleteTeamMember();
     }
+
+    public String getMemberNickName(){
+        return member.getNickName();
+    }
 }

--- a/src/test/java/com/moing/backend/domain/report/presentation/ReportControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/report/presentation/ReportControllerTest.java
@@ -1,7 +1,6 @@
 package com.moing.backend.domain.report.presentation;
 
 import com.moing.backend.config.CommonControllerTest;
-import com.moing.backend.domain.report.application.service.ReportCreateUseCase;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/src/test/java/com/moing/backend/domain/report/presentation/ReportControllerTest.java
+++ b/src/test/java/com/moing/backend/domain/report/presentation/ReportControllerTest.java
@@ -1,6 +1,7 @@
 package com.moing.backend.domain.report.presentation;
 
 import com.moing.backend.config.CommonControllerTest;
+import com.moing.backend.domain.report.application.service.ReportCreateUseCase;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/src/test/java/com/moing/backend/domain/team/application/service/CreateTeamUseCaseTest.java
+++ b/src/test/java/com/moing/backend/domain/team/application/service/CreateTeamUseCaseTest.java
@@ -1,0 +1,12 @@
+package com.moing.backend.domain.team.application.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CreateTeamUseCaseTest {
+
+    @Test
+    void createTeam() {
+    }
+}


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
- [x] 리팩토링
  
## 개요
- 신고하기 기능 전략패턴 적용해 유지보수성 높임

## 변경 사항
- 기존에는 여러 종류 (댓글, 게시글, 미션 게시글, 미션 댓글)이 모두 하나의 클래스에서 if-else로 되어 있어 OCP를 지키지 못함
- 따라서 전략패턴을 적용해 런타임시 해당 도메인의 신고하기 기능을 선택하게 해 OCP를 지켜 유지보수성을 높임

## 코드 리뷰 시 참고 사항
- MissionArchiveReportStrategy 부분이 여전히 if-else문이 남아 있는데 이 부분 수정 부탁드립니다...
https://github.com/Modagbul/MOING_Server_Release/blob/174b92a4e6e3a7990a8b0940b0dc676692e709f0/src/main/java/com/moing/backend/domain/report/application/service/MissionArchiveReportStrategy.java#L19-L50
