### PR TITLE
fix: 회원가입시 미션댓글 알림 여부 true로 수정

### DIFF
--- a/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/moing/backend/domain/member/domain/entity/Member.java
@@ -152,6 +152,7 @@ public class Member extends BaseTimeEntity {
         this.isNewUploadPush = allPush;
         this.isRemindPush = allPush;
         this.isFirePush = allPush;
+        this.isCommentPush=allPush;
     }
 
     public void updateFcmToken(String fcmToken) {


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [x] 기타 사소한 수정
  
## 개요
- 회원가입 시 미션 댓글 알림 여부 수정

## 변경 사항
- 회원가입할 때 미션 댓글 알림 여부도 true로 수정 (디폴트 값)
