### PR TITLE
MNG-28 feat: 푸시알림 보낼 때 idInfo에 tyep 추가 - 2

### DIFF
--- a/src/main/java/com/moing/backend/domain/boardComment/application/service/SendBoardCommentAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/boardComment/application/service/SendBoardCommentAlarmUseCase.java
@@ -65,7 +65,7 @@ public class SendBoardCommentAlarmUseCase {
         JSONObject jo = new JSONObject();
         jo.put("teamId", teamId);
         jo.put("boardId", boardId);
-        jo.put("type", "COMMENT");
+        jo.put("type", "COMMENT_BOARD");
         return jo.toJSONString();
     }
 

--- a/src/main/java/com/moing/backend/domain/fire/application/service/FireThrowAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/fire/application/service/FireThrowAlarmUseCase.java
@@ -33,7 +33,7 @@ public class FireThrowAlarmUseCase {
                 : getRandomTitle(throwMember.getNickName(), receiveMember.getNickName(), randomNum);
         String message = fireThrowReq != null ? fireThrowReq.getMessage()
                 : getRandomMessage(throwMember.getNickName(), receiveMember.getNickName(), randomNum);
-        String idInfo = createIdInfo(mission.getType() == MissionType.REPEAT, mission.getTeam().getTeamId(), mission.getId());
+        String idInfo = createIdInfo(mission.getType() == MissionType.REPEAT, mission.getTeam().getTeamId(), mission.getId(), fireThrowReq == null);
 
         eventPublisher.publishEvent(new SingleFcmEvent(receiveMember, title, message, idInfo, team.getName(), FIRE, MISSION_PATH.getValue(), receiveMember.isFirePush()));
     }
@@ -60,13 +60,19 @@ public class FireThrowAlarmUseCase {
         return NEW_FIRE_THROW_TITLE1.getMessage();
     }
 
-    private String createIdInfo(boolean isRepeated, Long teamId, Long missionId) {
+    private String createIdInfo(boolean isRepeated, Long teamId, Long missionId, boolean isMessageNull) {
         JSONObject jo = new JSONObject();
         jo.put("isRepeated", isRepeated);
         jo.put("teamId", teamId);
         jo.put("missionId", missionId);
-        jo.put("type", "FIRE");
+        jo.put("type", getType(isMessageNull));
         return jo.toJSONString();
+    }
+
+    private String getType(boolean isMessageNull){
+        if(isMessageNull)
+            return "FIRE_MESSAGE_NULL";
+        return "FIRE_MESSAGE_EXIST";
     }
 
 

--- a/src/main/java/com/moing/backend/domain/missionArchive/application/service/SendMissionArchiveCreateAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionArchive/application/service/SendMissionArchiveCreateAlarmUseCase.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import static com.moing.backend.domain.missionArchive.application.service.MissionArchiveCreateMessage.CREATOR_CREATE_MISSION_ARCHIVE;
 import static com.moing.backend.domain.missionArchive.application.service.MissionArchiveCreateMessage.TEAM_AND_TITLE;
-import static com.moing.backend.global.config.fcm.constant.NewMissionTitle.NEW_SINGLE_MISSION_COMING;
 
 @Service
 @Transactional
@@ -54,6 +53,7 @@ public class SendMissionArchiveCreateAlarmUseCase {
         jo.put("teamId", teamId);
         jo.put("missionId", missionId);
         jo.put("status", status.name());
+        jo.put("type", "COMPLETE_MISSION");
         return jo.toJSONString();
     }
 }

--- a/src/main/java/com/moing/backend/domain/missionComment/application/service/SendMissionCommentAlarmUseCase.java
+++ b/src/main/java/com/moing/backend/domain/missionComment/application/service/SendMissionCommentAlarmUseCase.java
@@ -85,6 +85,7 @@ public class SendMissionCommentAlarmUseCase {
         jo.put("missionArchiveId", missionArchiveId);
         jo.put("teamId", teamId);
         jo.put("missionId", missionId);
+        jo.put("type", "COMMENT_MISSION");
         return jo.toJSONString();
     }
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- 푸시 알림 클릭 관련 idInfo에 type 추가

## 변경 사항
|내용|type명|
|------|---|
|공지/게시글 댓글|COMMENT_BOARD|
|미션 댓글|COMMENT_MISSION|
|신규 공지|NEW_UPLOAD_BOARD|
|미션 생성|NEW_UPLOAD_MISSION|
|불 던지기(메시지 있음)|FIRE_MESSAGE_EXIST|
|불 던지기(메시지 없음)|FIRE_MESSAGE_NULL|
|미션 인증하기|COMPLETE_MISSION|


